### PR TITLE
libretro changes

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -23,6 +23,8 @@
 #define snprintf _snprintf
 #endif
 
+#define NES_8_7_PAR ((Api::Video::Output::WIDTH - (overscan_h ? 16 : 0)) * (8.0 / 7.0)) / (Api::Video::Output::HEIGHT - (overscan_v ? 16 : 0))
+
 using namespace Nes;
 
 static retro_log_printf_t log_cb;
@@ -285,7 +287,7 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
       Api::Video::Output::HEIGHT - (overscan_v ? 16 : 0),
       Api::Video::Output::NTSC_WIDTH,
       Api::Video::Output::HEIGHT,
-      4.0 / 3.0,
+      NES_8_7_PAR,
    };
    info->geometry = geom;
 }

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -24,6 +24,7 @@
 #endif
 
 #define NES_8_7_PAR ((Api::Video::Output::WIDTH - (overscan_h ? 16 : 0)) * (8.0 / 7.0)) / (Api::Video::Output::HEIGHT - (overscan_v ? 16 : 0))
+#define NES_4_3 4.0 / 3.0
 
 using namespace Nes;
 
@@ -55,6 +56,7 @@ static unsigned blargg_ntsc;
 static bool fds_auto_insert;
 static bool overscan_v;
 static bool overscan_h;
+static bool use_par;
 
 int16_t video_width = Api::Video::Output::WIDTH;
 size_t pitch;
@@ -287,7 +289,7 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
       Api::Video::Output::HEIGHT - (overscan_v ? 16 : 0),
       Api::Video::Output::NTSC_WIDTH,
       Api::Video::Output::HEIGHT,
-      NES_8_7_PAR,
+      use_par ? NES_8_7_PAR : NES_4_3,
    };
    info->geometry = geom;
 }
@@ -304,6 +306,7 @@ void retro_set_environment(retro_environment_t cb)
       { "nestopia_fds_auto_insert", "Automatically insert first FDS disk on reset; enabled|disabled" },
       { "nestopia_overscan_v", "Mask Overscan (Vertical); enabled|disabled" },
       { "nestopia_overscan_h", "Mask Overscan (Horizontal); disabled|enabled" },
+      { "nestopia_aspect" ,  "Core-provided aspect ratio; 8:7 PAR|4:3" },
       { "nestopia_genie_distortion", "Game Genie Sound Distortion; disabled|enabled" },
       { "nestopia_favored_system", "Favored System; auto|ntsc|pal|famicom|dendy" },
       { NULL, NULL },
@@ -641,6 +644,16 @@ static void check_variables(void)
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
       overscan_h = (strcmp(var.value, "enabled") == 0);
+
+   var.key = "nestopia_aspect";
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "8:7 PAR"))
+         use_par = true;
+      else if(!strcmp(var.value, "4:3"))
+         use_par = false;
+   }
    
    pitch = video_width * 4;
    

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -439,6 +439,7 @@ static void check_variables(void)
 {
    static bool last_ntsc_val_same;
    struct retro_variable var = {0};
+   struct retro_system_av_info av_info;
 
    Api::Sound sound(emulator);
    Api::Video video(emulator);
@@ -650,6 +651,9 @@ static void check_variables(void)
    renderState.bits.mask.b = 0x000000ff;
    if (NES_FAILED(video.SetRenderState( renderState )) && log_cb)
       log_cb(RETRO_LOG_INFO, "Nestopia core rejected render state\n");;
+
+   retro_get_system_av_info(&av_info);
+   environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &av_info);
 
 }
 


### PR DESCRIPTION
Made the core provided aspect ratio always have 8:7 PAR according to http://wiki.nesdev.com/w/index.php/Overscan
A core option allows you to switch between this and the original behavior (4:3 DAR).
Fixes libretro/RetroArch#2837

Also added RETRO_ENVIRONMENT_SET_GEOMETRY to check_variables so the frontend properly re-adjusts the screen when overscan or aspect ratio core options are changed.
