### PR TITLE
Silence several -Wswitch warnings

### DIFF
--- a/source/core/NstCartridge.cpp
+++ b/source/core/NstCartridge.cpp
@@ -118,23 +118,21 @@ namespace Nes
 
 				board->Load( savefile );
 
-				switch (profile.system.type)
+				if ((profile.system.type) == Profile::System::VS_UNISYSTEM)
 				{
-					case Profile::System::VS_UNISYSTEM:
+					vs = VsSystem::Create
+					(
+						context.cpu,
+						context.ppu,
+						static_cast<PpuModel>(profile.system.ppu),
+						prgCrc
+					);
 
-						vs = VsSystem::Create
-						(
-							context.cpu,
-							context.ppu,
-							static_cast<PpuModel>(profile.system.ppu),
-							prgCrc
-						);
-
-						profile.system.ppu = static_cast<Profile::System::Ppu>(vs->GetPpuModel());
-						break;
-
-					case Profile::System::VS_DUALSYSTEM:
-						throw RESULT_ERR_UNSUPPORTED_VSSYSTEM;
+					profile.system.ppu = static_cast<Profile::System::Ppu>(vs->GetPpuModel());
+				}
+				else if ((profile.system.type) == Profile::System::VS_DUALSYSTEM)
+				{
+					throw RESULT_ERR_UNSUPPORTED_VSSYSTEM;
 				}
 
 				if (Cartridge::QueryExternalDevice( EXT_DIP_SWITCHES ))
@@ -460,6 +458,13 @@ namespace Nes
 								*ppu = PPU_DENDY;
 
 							return SYSTEM_DENDY;
+
+						case Profile::System::VS_UNISYSTEM:
+						case Profile::System::VS_DUALSYSTEM:
+						case Profile::System::PLAYCHOICE_10:
+
+							default:
+							break;
 					}
 				}
 

--- a/source/core/NstCartridgeInes.cpp
+++ b/source/core/NstCartridgeInes.cpp
@@ -426,6 +426,12 @@ namespace Nes
 
 						profileEx.nmt = ProfileEx::NMT_FOURSCREEN;
 						break;
+
+					case Header::MIRRORING_SINGLESCREEN:
+					case Header::MIRRORING_CONTROLLED:
+
+						default:
+						break;
 				}
 
 				profile.system.cpu = Profile::System::CPU_RP2A03;

--- a/source/core/NstImageDatabase.cpp
+++ b/source/core/NstImageDatabase.cpp
@@ -1059,6 +1059,12 @@ namespace Nes
 									return it;
 
 								break;
+							case Profile::System::VS_UNISYSTEM:
+							case Profile::System::VS_DUALSYSTEM:
+							case Profile::System::PLAYCHOICE_10:
+
+								default:
+								break;
 						}
 					}
 

--- a/source/core/NstMachine.cpp
+++ b/source/core/NstMachine.cpp
@@ -104,17 +104,15 @@ namespace Nes
 
 					state |= Api::Machine::CARTRIDGE;
 
-					switch (static_cast<const Cartridge*>(image)->GetProfile().system.type)
+					if ((static_cast<const Cartridge*>(image)->GetProfile().system.type) == Api::Cartridge::Profile::System::VS_UNISYSTEM)
 					{
-						case Api::Cartridge::Profile::System::VS_UNISYSTEM:
 
-							state |= Api::Machine::VS;
-							break;
+						state |= Api::Machine::VS;
+					}
+					else if ((static_cast<const Cartridge*>(image)->GetProfile().system.type) == Api::Cartridge::Profile::System::PLAYCHOICE_10)
+					{
 
-						case Api::Cartridge::Profile::System::PLAYCHOICE_10:
-
-							state |= Api::Machine::PC10;
-							break;
+						state |= Api::Machine::PC10;
 					}
 					break;
 
@@ -126,6 +124,11 @@ namespace Nes
 				case Image::SOUND:
 
 					state |= Api::Machine::SOUND;
+					break;
+
+				case Image::UNKNOWN:
+
+					default:
 					break;
 			}
 
@@ -275,17 +278,8 @@ namespace Nes
 
 					bool acknowledged = true;
 
-					if (image)
-					{
-						switch (image->GetDesiredSystem((state & Api::Machine::NTSC) ? REGION_NTSC : REGION_PAL))
-						{
-							case SYSTEM_FAMICOM:
-							case SYSTEM_DENDY:
-
-								acknowledged = false;
-								break;
-						}
-					}
+					if (image && ((image->GetDesiredSystem((state & Api::Machine::NTSC) ? REGION_NTSC : REGION_PAL))) == (SYSTEM_FAMICOM || SYSTEM_DENDY))
+						acknowledged = false;
 
 					ppu.Reset( hard, acknowledged );
 

--- a/source/core/NstPpu.cpp
+++ b/source/core/NstPpu.cpp
@@ -137,37 +137,28 @@ namespace Nes
 					cpu.Map( i+7 ).Set( this,               &Ppu::Peek_2007,                   &Ppu::Poke_2007 );
 				}
 
-				switch (model)
+				if (model == (PPU_RC2C05_01 || PPU_RC2C05_04))
 				{
-					case PPU_RC2C05_01:
-					case PPU_RC2C05_02:
-					case PPU_RC2C05_03:
-					case PPU_RC2C05_04:
-
-						if (model == PPU_RC2C05_02)
-						{
-							for (uint i=0x2002; i < 0x4000; i += 0x8)
-								cpu.Map( i ).Set( &Ppu::Peek_2002_RC2C05_02 );
-						}
-						else if (model == PPU_RC2C05_03)
-						{
-							for (uint i=0x2002; i < 0x4000; i += 0x8)
-								cpu.Map( i ).Set( &Ppu::Peek_2002_RC2C05_03 );
-						}
-						else
-						{
-							for (uint i=0x2002; i < 0x4000; i += 0x8)
-								cpu.Map( i ).Set( &Ppu::Peek_2002_RC2C05_01_04 );
-						}
-
-					case PPU_RC2C05_05:
-
-						for (uint i=0x2000; i < 0x4000; i += 0x8)
-						{
-							cpu.Map( i+0 ).Set( &Ppu::Poke_2001 );
-							cpu.Map( i+1 ).Set( &Ppu::Poke_2000 );
-						}
-						break;
+					for (uint i=0x2002; i < 0x4000; i += 0x8)
+						cpu.Map( i ).Set( &Ppu::Peek_2002_RC2C05_01_04 );
+				}
+				else if (model == PPU_RC2C05_02)
+				{
+					for (uint i=0x2002; i < 0x4000; i += 0x8)
+						cpu.Map( i ).Set( &Ppu::Peek_2002_RC2C05_02 );
+				}
+				else if (model == PPU_RC2C05_03)
+				{
+					for (uint i=0x2002; i < 0x4000; i += 0x8)
+						cpu.Map( i ).Set( &Ppu::Peek_2002_RC2C05_03 );
+				}
+				else if (model == PPU_RC2C05_05)
+				{
+					for (uint i=0x2000; i < 0x4000; i += 0x8)
+					{
+						cpu.Map( i+0 ).Set( &Ppu::Poke_2001 );
+						cpu.Map( i+1 ).Set( &Ppu::Poke_2000 );
+					}
 				}
 
 				cpu.Map( 0x4014U ).Set( this, &Ppu::Peek_4014, &Ppu::Poke_4014 );

--- a/source/core/api/NstApiVideo.cpp
+++ b/source/core/api/NstApiVideo.cpp
@@ -306,13 +306,13 @@ namespace Nes
 
 		Video::Palette::Mode Video::Palette::GetMode() const throw()
 		{
-			switch (emulator.renderer.GetPaletteType())
+			if (emulator.renderer.GetPaletteType() == Core::Video::Renderer::PALETTE_YUV)
 			{
-				case Core::Video::Renderer::PALETTE_YUV:
-					return MODE_YUV;
-
-				case Core::Video::Renderer::PALETTE_CUSTOM:
-					return MODE_CUSTOM;
+				return MODE_YUV;
+			}
+			else if (emulator.renderer.GetPaletteType() == Core::Video::Renderer::PALETTE_CUSTOM)
+			{
+				return MODE_CUSTOM;
 			}
 
 			return MODE_RGB;

--- a/source/core/board/NstBoard.cpp
+++ b/source/core/board/NstBoard.cpp
@@ -432,6 +432,11 @@ namespace Nes
 								nmt.Source(1).SwapBank<SIZE_4K,0x0000>(0);
 							}
 							break;
+
+						case Type::NMT_CONTROLLED:
+
+							default:
+							break;
 					}
 				}
 
@@ -1192,16 +1197,13 @@ namespace Nes
 
 						if (wram)
 						{
-							switch (id)
-							{
-								case Type::KONAMI_VRC4_0:  id = (wram > SIZE_2K ? Type::KONAMI_VRC4_2 : Type::KONAMI_VRC4_1); break;
-								case Type::KONAMI_VRC6_0:  id = Type::KONAMI_VRC6_1; break;
-								case Type::KONAMI_VRC7_0:  id = Type::KONAMI_VRC7_1; break;
-								case Type::IREM_G101A_0:   id = Type::IREM_G101A_1; break;
-								case Type::IREM_G101B_0:   id = Type::IREM_G101B_1; break;
-								case Type::SUNSOFT_FME7_0: id = Type::SUNSOFT_FME7_1; break;
-								case Type::SUNSOFT_5B_0:   id = Type::SUNSOFT_5B_1; break;
-							}
+							if (id == Type::KONAMI_VRC4_0)       { id = (wram > SIZE_2K ? Type::KONAMI_VRC4_2 : Type::KONAMI_VRC4_1); }
+							else if (id == Type::KONAMI_VRC6_0)  { id = Type::KONAMI_VRC6_1; }
+							else if (id == Type::KONAMI_VRC7_0)  { id = Type::KONAMI_VRC7_1; }
+							else if (id == Type::IREM_G101A_0)   { id = Type::IREM_G101A_1; }
+							else if (id == Type::IREM_G101B_0)   { id = Type::IREM_G101B_1; }
+							else if (id == Type::SUNSOFT_FME7_0) { id = Type::SUNSOFT_FME7_1; }
+							else if (id == Type::SUNSOFT_5B_0)   { id = Type::SUNSOFT_5B_1; }
 						}
 						break;
 				}
@@ -3678,6 +3680,7 @@ namespace Nes
 					case Type::WAIXING_SECURITY_0         :
 					case Type::WAIXING_SECURITY_1         : return new Waixing::Security(c);
 					case Type::WHIRLWIND_2706             : return new Whirlwind::W2706(c);
+					case Type::UNKNOWN                    : default: break;
 				}
 
 				return NULL;

--- a/source/core/board/NstBoardBmcVt5201.cpp
+++ b/source/core/board/NstBoardBmcVt5201.cpp
@@ -117,6 +117,7 @@ namespace Nes
 						case VT5201_54IN1: id = 4; break;
 						case VT5201_55IN1: id = 5; break;
 						case VT5201_65IN1: id = 6; break;
+						case VT5201_XIN1: default: break;
 					}
 
 					return names[id][i];

--- a/source/core/board/NstBoardFfe.cpp
+++ b/source/core/board/NstBoardFfe.cpp
@@ -88,42 +88,34 @@ namespace Nes
 					Map( 0x4503U, &Ffe::Poke_4503 );
 				}
 
-				switch (board.GetId())
+				if (board.GetId() == Type::CUSTOM_FFE3)
 				{
-					case Type::CUSTOM_FFE3:
+					Map( 0x8000U, 0xFFFFU, &Ffe::Poke_Prg_F3 );
 
-						Map( 0x8000U, 0xFFFFU, &Ffe::Poke_Prg_F3 );
+					if (hard)
+						prg.SwapBank<SIZE_32K,0x0000>(0);
+				}
+				else if (board.GetId() == Type::CUSTOM_FFE4)
+				{
+					Map( 0x8000U, 0xFFFFU, &Ffe::Poke_Prg_F4 );
 
-						if (hard)
-							prg.SwapBank<SIZE_32K,0x0000>(0);
-
-						break;
-
-					case Type::CUSTOM_FFE4:
-
-						Map( 0x8000U, 0xFFFFU, &Ffe::Poke_Prg_F4 );
-
-						if (hard)
-							prg.SwapBank<SIZE_16K,0x4000>(7);
-
-						break;
-
-					case Type::CUSTOM_FFE8:
-
-						Map( 0x4504U, PRG_SWAP_8K_0 );
-						Map( 0x4505U, PRG_SWAP_8K_1 );
-						Map( 0x4506U, PRG_SWAP_8K_2 );
-						Map( 0x4507U, PRG_SWAP_8K_3 );
-						Map( 0x4510U, CHR_SWAP_1K_0 );
-						Map( 0x4511U, CHR_SWAP_1K_1 );
-						Map( 0x4512U, CHR_SWAP_1K_2 );
-						Map( 0x4513U, CHR_SWAP_1K_3 );
-						Map( 0x4514U, CHR_SWAP_1K_4 );
-						Map( 0x4515U, CHR_SWAP_1K_5 );
-						Map( 0x4516U, CHR_SWAP_1K_6 );
-						Map( 0x4517U, CHR_SWAP_1K_7 );
-
-						break;
+					if (hard)
+						prg.SwapBank<SIZE_16K,0x4000>(7);
+				}
+				else if (board.GetId() == Type::CUSTOM_FFE8)
+				{
+					Map( 0x4504U, PRG_SWAP_8K_0 );
+					Map( 0x4505U, PRG_SWAP_8K_1 );
+					Map( 0x4506U, PRG_SWAP_8K_2 );
+					Map( 0x4507U, PRG_SWAP_8K_3 );
+					Map( 0x4510U, CHR_SWAP_1K_0 );
+					Map( 0x4511U, CHR_SWAP_1K_1 );
+					Map( 0x4512U, CHR_SWAP_1K_2 );
+					Map( 0x4513U, CHR_SWAP_1K_3 );
+					Map( 0x4514U, CHR_SWAP_1K_4 );
+					Map( 0x4515U, CHR_SWAP_1K_5 );
+					Map( 0x4516U, CHR_SWAP_1K_6 );
+					Map( 0x4517U, CHR_SWAP_1K_7 );
 				}
 			}
 

--- a/source/core/vssystem/NstVsSystem.cpp
+++ b/source/core/vssystem/NstVsSystem.cpp
@@ -1397,6 +1397,7 @@ namespace Nes
 				case TYPE_3: return new Type3;
 				case TYPE_4: return new Type4;
 				case TYPE_5: return new Type5;
+				case TYPE_NONE: default: break;
 			}
 
 			return NULL;


### PR DESCRIPTION
This tries to correctly silence several `-Wswitch` warnings about unhandled cases found with clang. This accomplishes this through two methods.
1. If there are a only a few unhandled cases it will handle them with a simple `default: break;`.
2. If there are 4 or more unhandled cases, this changes those switch statments to if-else statements. This, allows handling only the intended cases, I suspect the speed difference will be neglible.

Please review in case I did something wrong, suggestions are of course welcome.

Here are the warnings for reference.
http://pastebin.com/JcVP5FT0