### PR TITLE
Silence -Wparentheses warnings

### DIFF
--- a/source/core/NstCartridge.cpp
+++ b/source/core/NstCartridge.cpp
@@ -278,7 +278,7 @@ namespace Nes
 
 			if (profile.board.type.empty() || !b.DetectBoard( profile.board.type.c_str(), profile.board.GetWram() ))
 			{
-				if (profile.board.mapper == Profile::Board::NO_MAPPER || !b.DetectBoard( profile.board.mapper, profile.board.GetWram(), profileEx.wramAuto, profile.board.subMapper ) && board)
+				if (profile.board.mapper == Profile::Board::NO_MAPPER || (!b.DetectBoard( profile.board.mapper, profile.board.GetWram(), profileEx.wramAuto, profile.board.subMapper ) && board))
 					return RESULT_ERR_UNSUPPORTED_MAPPER;
 
 				if (profile.board.type.empty())

--- a/source/core/NstFds.cpp
+++ b/source/core/NstFds.cpp
@@ -962,7 +962,7 @@ namespace Nes
 				count = 0;
 				status |= uint(STATUS_UNREADY);
 			}
-			else if (!(reg & CTRL_STOP | count) && io)
+			else if (!((reg & CTRL_STOP) | count) && io)
 			{
 				count = CLK_MOTOR;
 				headPos = 0;
@@ -1284,7 +1284,7 @@ namespace Nes
 					State::Loader::Data<16> data( state );
 
 					unit.drive.ctrl = data[0];
-					unit.drive.status = data[1] & (Unit::Drive::STATUS_EJECTED|Unit::Drive::STATUS_UNREADY|Unit::Drive::STATUS_PROTECTED) | OPEN_BUS;
+					unit.drive.status = (data[1] & (Unit::Drive::STATUS_EJECTED|Unit::Drive::STATUS_UNREADY|Unit::Drive::STATUS_PROTECTED)) | OPEN_BUS;
 					unit.drive.in = data[2] | (data[15] << 8 & 0x100);
 					unit.drive.out = data[3];
 					unit.drive.headPos = data[4] | data[5] << 8;

--- a/source/core/NstPpu.cpp
+++ b/source/core/NstPpu.cpp
@@ -312,7 +312,7 @@ namespace Nes
 		void Ppu::UpdatePalette()
 		{
 			for (uint i=0, c=Coloring(), e=Emphasis(); i < Palette::SIZE; ++i)
-				output.palette[i] = (rgbMap ? rgbMap[palette.ram[i] & uint(Palette::COLOR)] : palette.ram[i]) & c | e;
+				output.palette[i] = ((rgbMap ? rgbMap[palette.ram[i] & uint(Palette::COLOR)] : palette.ram[i]) & c) | e;
 		}
 
 		void Ppu::SaveState(State::Saver& state,const dword baseChunk) const
@@ -810,12 +810,12 @@ namespace Nes
 					if (!map)
 					{
 						for (uint i=0; i < Palette::SIZE; ++i)
-							output.palette[i] = palette.ram[i] & ce[0] | ce[1];
+							output.palette[i] = (palette.ram[i] & ce[0]) | ce[1];
 					}
 					else
 					{
 						for (uint i=0; i < Palette::SIZE; ++i)
-							output.palette[i] = map[palette.ram[i] & Palette::COLOR] & ce[0] | ce[1];
+							output.palette[i] = (map[palette.ram[i] & Palette::COLOR] & ce[0]) | ce[1];
 					}
 				}
 			}
@@ -836,17 +836,17 @@ namespace Nes
 
 		NES_PEEK_A(Ppu,2002_RC2C05_01_04)
 		{
-			return NES_DO_PEEK(2002,address) & 0xC0 | 0x1B;
+			return (NES_DO_PEEK(2002,address) & 0xC0) | 0x1B;
 		}
 
 		NES_PEEK_A(Ppu,2002_RC2C05_02)
 		{
-			return NES_DO_PEEK(2002,address) & 0xC0 | 0x3D;
+			return (NES_DO_PEEK(2002,address) & 0xC0) | 0x3D;
 		}
 
 		NES_PEEK_A(Ppu,2002_RC2C05_03)
 		{
-			return NES_DO_PEEK(2002,address) & 0xC0 | 0x1C;
+			return (NES_DO_PEEK(2002,address) & 0xC0) | 0x1C;
 		}
 
 		NES_POKE_D(Ppu,2003)
@@ -967,7 +967,7 @@ namespace Nes
 			{
 				address &= 0x1F;
 
-				const uint final = (!rgbMap ? data : rgbMap[data & Palette::COLOR]) & Coloring() | Emphasis();
+				const uint final = ((!rgbMap ? data : rgbMap[data & Palette::COLOR]) & Coloring()) | Emphasis();
 
 				palette.ram[address] = data;
 				output.palette[address] = final;
@@ -1311,7 +1311,7 @@ namespace Nes
 				address = (regs.ctrl[0] & Regs::CTRL0_SP_OFFSET) << 9 | buffer[1] << 4;
 			}
 
-			return address | comparitor & Oam::XFINE;
+			return address | (comparitor & Oam::XFINE);
 		}
 
 		NST_FORCE_INLINE void Ppu::LoadSprite(const uint pattern0,const uint pattern1,const byte* const NST_RESTRICT buffer)

--- a/source/core/api/NstApiCheats.cpp
+++ b/source/core/api/NstApiCheats.cpp
@@ -247,7 +247,7 @@ namespace Nes
 				}
 			}
 
-			code.address    = output & 0x7FFF | 0x8000;
+			code.address    = (output & 0x7FFF) | 0x8000;
 			code.compare    = output >> 16 & 0xFF;
 			code.value      = output >> 24 & 0xFF;
 			code.useCompare = true;

--- a/source/core/board/NstBoardAveD1012.cpp
+++ b/source/core/board/NstBoardAveD1012.cpp
@@ -82,7 +82,7 @@ namespace Nes
 				void D1012::Update()
 				{
 					prg.SwapBank<SIZE_32K,0x0000>( (regs[0] & 0xE) | (regs[regs[0] >> 6 & 0x1] & 0x1) );
-					chr.SwapBank<SIZE_8K,0x0000>( (regs[0] << 2 & (regs[0] >> 4 & 0x4 ^ 0x3C)) | (regs[1] >> 4 & (regs[0] >> 4 & 0x4 | 0x3)) );
+					chr.SwapBank<SIZE_8K,0x0000>( (regs[0] << 2 & ((regs[0] >> 4 & 0x4) ^ 0x3C)) | (regs[1] >> 4 & ((regs[0] >> 4 & 0x4) | 0x3)) );
 				}
 
 				NES_POKE_D(D1012,FF80)

--- a/source/core/board/NstBoardBandaiKaraokeStudio.cpp
+++ b/source/core/board/NstBoardBandaiKaraokeStudio.cpp
@@ -71,7 +71,7 @@ namespace Nes
 						if (controllers)
 						{
 							Input::Controllers::KaraokeStudio::callback( controllers->karaokeStudio );
-							mic = controllers->karaokeStudio.buttons & 0x7 ^ 0x3;
+							mic = (controllers->karaokeStudio.buttons & 0x7) ^ 0x3;
 						}
 						else
 						{

--- a/source/core/board/NstBoardBmc20in1.cpp
+++ b/source/core/board/NstBoardBmc20in1.cpp
@@ -51,7 +51,7 @@ namespace Nes
 
 				NES_POKE_A(B20in1,8000)
 				{
-					prg.SwapBanks<SIZE_16K,0x0000>( address & 0x1E, address & 0x1E | (address >> 5 & 0x1) );
+					prg.SwapBanks<SIZE_16K,0x0000>( address & 0x1E, (address & 0x1E) | (address >> 5 & 0x1) );
 					ppu.SetMirroring( (address & 0x80) ? Ppu::NMT_H : Ppu::NMT_V );
 				}
 			}

--- a/source/core/board/NstBoardBmcFk23c.cpp
+++ b/source/core/board/NstBoardBmcFk23c.cpp
@@ -366,7 +366,7 @@ namespace Nes
 
 							if (exRegs[3] << 2 & (regs.ctrl0 & 0x8))
 							{
-								exRegs[4 | regs.ctrl0 & 0x3] = data;
+								exRegs[4 | (regs.ctrl0 & 0x3)] = data;
 
 								Fk23c::UpdatePrg();
 								Fk23c::UpdateChr();

--- a/source/core/board/NstBoardBmcPowerjoy84in1.cpp
+++ b/source/core/board/NstBoardBmcPowerjoy84in1.cpp
@@ -98,7 +98,7 @@ namespace Nes
 
 				void NST_FASTCALL Powerjoy84in1::UpdatePrg(uint address,uint bank)
 				{
-					bank &= ~uint(exRegs[0]) >> 2 & 0x10 | 0x0F;
+					bank &= (~uint(exRegs[0]) >> 2 & 0x10) | 0x0F;
 					bank |= (exRegs[0] & (0x6U | (exRegs[0] & 0x40U) >> 6)) << 4 | (exRegs[0] & 0x10U) << 3;
 
 					if (!(exRegs[3] & 0x3U))

--- a/source/core/board/NstBoardMmc1.cpp
+++ b/source/core/board/NstBoardMmc1.cpp
@@ -151,7 +151,7 @@ namespace Nes
 				chr.SwapBanks<SIZE_4K,0x0000>
 				(
 					regs[CHR0] & (0x1E | mode),
-					regs[CHR0+mode] & 0x1FU | (mode^1)
+					(regs[CHR0+mode] & 0x1FU) | (mode^1)
 				);
 			}
 

--- a/source/core/board/NstBoardMmc5.cpp
+++ b/source/core/board/NstBoardMmc5.cpp
@@ -713,7 +713,7 @@ namespace Nes
 
 				if (bank & Regs::PRG_ROM_SELECT)
 				{
-					banks.security = banks.security & ~uint(RAM) | ROM;
+					banks.security = (banks.security & ~uint(RAM)) | ROM;
 					static_cast<Prg::SourceProxy>(prg.Source(0)).SwapBank<SIZE_8K,ADDRESS>( bank & Regs::PRG_ROM_BANK );
 				}
 				else if (Banks::Wrk::INVALID != (bank = banks.wrk[bank & Regs::PRG_RAM_BANK]))
@@ -742,13 +742,13 @@ namespace Nes
 				{
 					case Regs::PRG_MODE_32K:
 
-						banks.security = banks.security & ~uint(RAM_8_A_C) | ROM_8_A_C;
+						banks.security = (banks.security & ~uint(RAM_8_A_C)) | ROM_8_A_C;
 						prg.SwapBank<SIZE_32K,0x0000>( banks.prg[3] >> 2 );
 						break;
 
 					case Regs::PRG_MODE_16K:
 
-						banks.security = banks.security & ~uint(RAM_C) | ROM_C;
+						banks.security = (banks.security & ~uint(RAM_C)) | ROM_C;
 						SwapPrg8Ex<0x0000>( banks.prg[1] & 0xFEU );
 						SwapPrg8Ex<0x2000>( banks.prg[1] | 0x01U );
 						prg.SwapBank<SIZE_16K,0x4000>( banks.prg[3] >> 1 );

--- a/source/core/board/NstBoardSachenS8259.cpp
+++ b/source/core/board/NstBoardSachenS8259.cpp
@@ -142,10 +142,10 @@ namespace Nes
 
 									chr.SwapBanks<SIZE_2K,0x0000>
 									(
-										(regs[(regs[7] & 0x1U) ? 0 : 0] & 0x07U | h) << s,
-										(regs[(regs[7] & 0x1U) ? 0 : 1] & 0x07U | h) << s | (board != Type::SACHEN_8259B ? 1 : 0),
-										(regs[(regs[7] & 0x1U) ? 0 : 2] & 0x07U | h) << s | (board == Type::SACHEN_8259C ? 2 : 0),
-										(regs[(regs[7] & 0x1U) ? 0 : 3] & 0x07U | h) << s | (board == Type::SACHEN_8259A ? 1 : board == Type::SACHEN_8259C ? 3 : 0)
+										((regs[(regs[7] & 0x1U) ? 0 : 0] & 0x07U) | h) << s,
+										((regs[(regs[7] & 0x1U) ? 0 : 1] & 0x07U) | h) << s | (board != Type::SACHEN_8259B ? 1 : 0),
+										((regs[(regs[7] & 0x1U) ? 0 : 2] & 0x07U) | h) << s | (board == Type::SACHEN_8259C ? 2 : 0),
+										((regs[(regs[7] & 0x1U) ? 0 : 3] & 0x07U) | h) << s | (board == Type::SACHEN_8259A ? 1 : board == Type::SACHEN_8259C ? 3 : 0)
 									);
 								}
 							}

--- a/source/core/board/NstBoardSachenStreetHeroes.cpp
+++ b/source/core/board/NstBoardSachenStreetHeroes.cpp
@@ -146,12 +146,12 @@ namespace Nes
 					{
 						chr.SwapBank<SIZE_1K>
 						(
-							address, exReg <<
+							address, (exReg <<
 							(
 								address < 0x0800 ? 5 :
 								address < 0x1000 ? 6 :
 								address < 0x1800 ? 8 : 7
-							)   & 0x100 | bank
+							)   & 0x100) | bank
 						);
 					}
 				}

--- a/source/core/board/NstBoardSunsoftDcs.cpp
+++ b/source/core/board/NstBoardSunsoftDcs.cpp
@@ -96,7 +96,7 @@ namespace Nes
 
 				NES_PEEK_A(Dcs,8000)
 				{
-					if (const uint bank = ((prgBank & 0x8 && counter < SIGNAL && ++counter == SIGNAL) ? (prgBank & 0x7 | 0x10) : 0))
+					if (const uint bank = ((prgBank & 0x8 && counter < SIGNAL && ++counter == SIGNAL) ? ((prgBank & 0x7) | 0x10) : 0))
 						prg.SwapBank<SIZE_16K,0x0000>( bank & 0xF );
 
 					return prg.Peek( address - 0x8000 );

--- a/source/core/board/NstBoardWaixingSh2.cpp
+++ b/source/core/board/NstBoardWaixingSh2.cpp
@@ -63,7 +63,7 @@ namespace Nes
 							{
 								const uint data = state.Read8();
 								selector[0] = data << 1 & 0x2;
-								selector[1] = data & 0x2 | 0x4;
+								selector[1] = (data & 0x2) | 0x4;
 							}
 
 							state.End();

--- a/source/core/vssystem/NstVsSystem.cpp
+++ b/source/core/vssystem/NstVsSystem.cpp
@@ -1471,7 +1471,7 @@ namespace Nes
 
 		NES_PEEK_A(Cartridge::VsSystem,4016)
 		{
-			return dips.Reg(0) | p4016.Peek( address ) & (STATUS_4016_MASK^0xFFU);
+			return dips.Reg(0) | (p4016.Peek( address ) & (STATUS_4016_MASK^0xFFU));
 		}
 
 		NES_POKE_AD(Cartridge::VsSystem,4016)
@@ -1481,7 +1481,7 @@ namespace Nes
 
 		NES_PEEK_A(Cartridge::VsSystem,4017)
 		{
-			return dips.Reg(1) | p4017.Peek( address ) & (STATUS_4017_MASK^0xFFU);
+			return dips.Reg(1) | (p4017.Peek( address ) & (STATUS_4017_MASK^0xFFU));
 		}
 
 		NES_POKE_AD(Cartridge::VsSystem,4017)


### PR DESCRIPTION
Hopefully correctly silences the following warnings.
```
g++ -c -o ../source/core/NstChecksum.o ../source/core/NstChecksum.cpp -DGIT_VERSION=\"" 9fa43cb"\" -Wparentheses -O3 -std=gnu++98 -fPIC -D__LIBRETRO__  -Wno-deprecated -Wno-write-strings  -DNST_NO_ZLIB -I../libretro  -I.. -fno-rtti -I.. -I../source
../source/core/NstCartridge.cpp: In static member function ‘static Nes::Result Nes::Core::Cartridge::SetupBoard(Nes::Core::Ram&, Nes::Core::Ram&, Nes::Core::Boards::Board**, const Nes::Core::Image::Context*, Nes::Core::Cartridge::Profile&, const Nes::Core::Cartridge::ProfileEx&, Nes::dword*, bool)’:
../source/core/NstCartridge.cpp:279:171: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
     if (profile.board.mapper == Profile::Board::NO_MAPPER || !b.DetectBoard( profile.board.mapper, profile.board.GetWram(), profileEx.wramAuto, profile.board.subMapper ) && board)
                                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~


g++ -c -o ../source/core/NstFile.o ../source/core/NstFile.cpp -DGIT_VERSION=\"" 9fa43cb"\" -Wparentheses -O3 -std=gnu++98 -fPIC -D__LIBRETRO__  -Wno-deprecated -Wno-write-strings  -DNST_NO_ZLIB -I../libretro  -I.. -fno-rtti -I.. -I../source
../source/core/NstFds.cpp: In member function ‘void Nes::Core::Fds::Unit::Drive::Write(Nes::uint)’:
../source/core/NstFds.cpp:965:19: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
    else if (!(reg & CTRL_STOP | count) && io)
               ~~~~^~~~~~~~~~~
../source/core/NstFds.cpp: In member function ‘void Nes::Core::Fds::Adapter::LoadState(Nes::Core::State::Loader&, Nes::dword, Nes::Core::Ppu&)’:
../source/core/NstFds.cpp:1287:34: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
      unit.drive.status = data[1] & (Unit::Drive::STATUS_EJECTED|Unit::Drive::STATUS_UNREADY|Unit::Drive::STATUS_PROTECTED) | OPEN_BUS;
                          ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


g++ -c -o ../source/core/NstRam.o ../source/core/NstRam.cpp -DGIT_VERSION=\"" 9fa43cb"\" -Wparentheses -O3 -std=gnu++98 -fPIC -D__LIBRETRO__  -Wno-deprecated -Wno-write-strings  -DNST_NO_ZLIB -I../libretro  -I.. -fno-rtti -I.. -I../source
../source/core/NstPpu.cpp: In member function ‘void Nes::Core::Ppu::UpdatePalette()’:
../source/core/NstPpu.cpp:306:99: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
     output.palette[i] = (rgbMap ? rgbMap[palette.ram[i] & uint(Palette::COLOR)] : palette.ram[i]) & c | e;
                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
../source/core/NstPpu.cpp: In member function ‘void Nes::Core::Ppu::Poke_M_2001(Nes::Core::Address, Nes::Core::Data)’:
../source/core/NstPpu.cpp:804:43: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
        output.palette[i] = palette.ram[i] & ce[0] | ce[1];
                            ~~~~~~~~~~~~~~~^~~~~~~
../source/core/NstPpu.cpp:809:65: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
        output.palette[i] = map[palette.ram[i] & Palette::COLOR] & ce[0] | ce[1];
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
../source/core/NstPpu.cpp: In member function ‘Nes::Core::Data Nes::Core::Ppu::Peek_M_2002_RC2C05_01_04(Nes::Core::Address)’:
../source/core/NstPpu.cpp:830:37: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
    return NES_DO_PEEK(2002,address) & 0xC0 | 0x1B;
../source/core/NstPpu.cpp: In member function ‘Nes::Core::Data Nes::Core::Ppu::Peek_M_2002_RC2C05_02(Nes::Core::Address)’:
../source/core/NstPpu.cpp:835:37: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
    return NES_DO_PEEK(2002,address) & 0xC0 | 0x3D;
../source/core/NstPpu.cpp: In member function ‘Nes::Core::Data Nes::Core::Ppu::Peek_M_2002_RC2C05_03(Nes::Core::Address)’:
../source/core/NstPpu.cpp:840:37: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
    return NES_DO_PEEK(2002,address) & 0xC0 | 0x1C;
../source/core/NstPpu.cpp: In member function ‘void Nes::Core::Ppu::Poke_M_2007(Nes::Core::Address, Nes::Core::Data)’:
../source/core/NstPpu.cpp:961:73: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
     const uint final = (!rgbMap ? data : rgbMap[data & Palette::COLOR]) & Coloring() | Emphasis();
                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
../source/core/NstPpu.cpp: In member function ‘Nes::uint Nes::Core::Ppu::OpenSprite(const byte*) const’:
../source/core/NstPpu.cpp:1305:32: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
    return address | comparitor & Oam::XFINE;
                     ~~~~~~~~~~~^~~~~


g++ -c -o ../source/core/api/NstApiDipSwitches.o ../source/core/api/NstApiDipSwitches.cpp -DGIT_VERSION=\"" 9fa43cb"\" -Wparentheses -O3 -std=gnu++98 -fPIC -D__LIBRETRO__  -Wno-deprecated -Wno-write-strings  -DNST_NO_ZLIB -I../libretro  -I.. -fno-rtti -I.. -I../source
../source/core/api/NstApiCheats.cpp: In static member function ‘static Nes::Result Nes::Api::Cheats::ProActionRockyDecode(const char*, Nes::Api::Cheats::Code&)’:
../source/core/api/NstApiCheats.cpp:250:29: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
    code.address    = output & 0x7FFF | 0x8000;
                      ~~~~~~~^~~~~~~~


g++ -c -o ../source/core/board/NstBoardAveNina.o ../source/core/board/NstBoardAveNina.cpp -DGIT_VERSION=\"" 9fa43cb"\" -Wparentheses -O3 -std=gnu++98 -fPIC -D__LIBRETRO__  -Wno-deprecated -Wno-write-strings  -DNST_NO_ZLIB -I../libretro  -I.. -fno-rtti -I.. -I../source
../source/core/board/NstBoardAveD1012.cpp: In member function ‘void Nes::Core::Boards::Ave::D1012::Update()’:
../source/core/board/NstBoardAveD1012.cpp:85:66: warning: suggest parentheses around arithmetic in operand of ‘^’ [-Wparentheses]
      chr.SwapBank<SIZE_8K,0x0000>( (regs[0] << 2 & (regs[0] >> 4 & 0x4 ^ 0x3C)) | (regs[1] >> 4 & (regs[0] >> 4 & 0x4 | 0x3)) );
                                                     ~~~~~~~~~~~~~^~~~~
../source/core/board/NstBoardAveD1012.cpp:85:113: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
 ] << 2 & (regs[0] >> 4 & 0x4 ^ 0x3C)) | (regs[1] >> 4 & (regs[0] >> 4 & 0x4 | 0x3)) );
                                                          ~~~~~~~~~~~~~^~~~~


g++ -c -o ../source/core/board/NstBoardBandaiOekaKids.o ../source/core/board/NstBoardBandaiOekaKids.cpp -DGIT_VERSION=\"" 9fa43cb"\" -Wparentheses -O3 -std=gnu++98 -fPIC -D__LIBRETRO__  -Wno-deprecated -Wno-write-strings  -DNST_NO_ZLIB -I../libretro  -I.. -fno-rtti -I.. -I../source
../source/core/board/NstBoardBandaiKaraokeStudio.cpp: In member function ‘virtual void Nes::Core::Boards::Bandai::KaraokeStudio::Sync(Nes::Core::Boards::Board::Event, Nes::Core::Input::Controllers*)’:
../source/core/board/NstBoardBandaiKaraokeStudio.cpp:74:49: warning: suggest parentheses around arithmetic in operand of ‘^’ [-Wparentheses]
        mic = controllers->karaokeStudio.buttons & 0x7 ^ 0x3;
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~


g++ -c -o ../source/core/board/NstBoardBmc31in1.o ../source/core/board/NstBoardBmc31in1.cpp -DGIT_VERSION=\"" 9fa43cb"\" -Wparentheses -O3 -std=gnu++98 -fPIC -D__LIBRETRO__  -Wno-deprecated -Wno-write-strings  -DNST_NO_ZLIB -I../libretro  -I.. -fno-rtti -I.. -I../source
../source/core/board/NstBoardBmc20in1.cpp: In member function ‘void Nes::Core::Boards::Bmc::B20in1::Poke_M_8000(Nes::Core::Address, Nes::Core::Data)’:
../source/core/board/NstBoardBmc20in1.cpp:54:62: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
      prg.SwapBanks<SIZE_16K,0x0000>( address & 0x1E, address & 0x1E | (address >> 5 & 0x1) );
                                                      ~~~~~~~~^~~~~~


g++ -c -o ../source/core/board/NstBoardBmcGolden190in1.o ../source/core/board/NstBoardBmcGolden190in1.cpp -DGIT_VERSION=\"" 9fa43cb"\" -Wparentheses -O3 -std=gnu++98 -fPIC -D__LIBRETRO__  -Wno-deprecated -Wno-write-strings  -DNST_NO_ZLIB -I../libretro  -I.. -fno-rtti -I.. -I../source
../source/core/board/NstBoardBmcFk23c.cpp: In member function ‘void Nes::Core::Boards::Bmc::Fk23c::Poke_M_8000(Nes::Core::Address, Nes::Core::Data)’:
../source/core/board/NstBoardBmcFk23c.cpp:369:31: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
         exRegs[4 | regs.ctrl0 & 0x3] = data;
                    ~~~~~~~~~~~^~~~~


g++ -c -o ../source/core/board/NstBoardBmcSuper22Games.o ../source/core/board/NstBoardBmcSuper22Games.cpp -DGIT_VERSION=\"" 9fa43cb"\" -Wparentheses -O3 -std=gnu++98 -fPIC -D__LIBRETRO__  -Wno-deprecated -Wno-write-strings  -DNST_NO_ZLIB -I../libretro  -I.. -fno-rtti -I.. -I../source
../source/core/board/NstBoardBmcPowerjoy84in1.cpp: In member function ‘virtual void Nes::Core::Boards::Bmc::Powerjoy84in1::UpdatePrg(Nes::uint, Nes::uint)’:
../source/core/board/NstBoardBmcPowerjoy84in1.cpp:101:36: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
      bank &= ~uint(exRegs[0]) >> 2 & 0x10 | 0x0F;
              ~~~~~~~~~~~~~~~~~~~~~~^~~~~~


 ../source/core/board/NstBoardMmc5.cpp -DGIT_VERSION=\"" 9fa43cb"\" -Wparentheses -O3 -std=gnu++98 -fPIC -D__LIBRETRO__  -Wno-deprecated -Wno-write-strings  -DNST_NO_ZLIB -I../libretro  -I.. -fno-rtti -I.. -I../source
../source/core/board/NstBoardMmc1.cpp: In member function ‘void Nes::Core::Boards::Mmc1::UpdateChr() const’:
../source/core/board/NstBoardMmc1.cpp:154:22: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
      regs[CHR0+mode] & 0x1FU | (mode^1)
      ~~~~~~~~~~~~~~~~^~~~~~~
g++ -c -o ../source/core/board/NstBoardMmc6.o ../source/core/board/NstBoardMmc6.cpp -DGIT_VERSION=\"" 9fa43cb"\" -Wparentheses -O3 -std=gnu++98 -fPIC -D__LIBRETRO__  -Wno-deprecated -Wno-write-strings  -DNST_NO_ZLIB -I../libretro  -I.. -fno-rtti -I.. -I../source
../source/core/board/NstBoardMmc5.cpp: In member function ‘void Nes::Core::Boards::Mmc5::UpdatePrg()’:
../source/core/board/NstBoardMmc5.cpp:745:39: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
       banks.security = banks.security & ~uint(RAM_8_A_C) | ROM_8_A_C;
                        ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
../source/core/board/NstBoardMmc5.cpp:751:39: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
       banks.security = banks.security & ~uint(RAM_C) | ROM_C;
                        ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
g++ -c -o ../source/core/board/NstBoardNamcot163.o ../source/core/board/NstBoardNamcot163.cpp -DGIT_VERSION=\"" 9fa43cb"\" -Wparentheses -O3 -std=gnu++98 -fPIC -D__LIBRETRO__  -Wno-deprecated -Wno-write-strings  -DNST_NO_ZLIB -I../libretro  -I.. -fno-rtti -I.. -I../source
../source/core/board/NstBoardMmc5.cpp: In instantiation of ‘void Nes::Core::Boards::Mmc5::SwapPrg8Ex(Nes::uint) [with unsigned int ADDRESS = 0; Nes::uint = unsigned int]’:
../source/core/board/NstBoardMmc5.cpp:752:48:   required from here
../source/core/board/NstBoardMmc5.cpp:716:38: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
      banks.security = banks.security & ~uint(RAM) | ROM;
                       ~~~~~~~~~~~~~~~^~~~~~~~~~~~
../source/core/board/NstBoardMmc5.cpp: In instantiation of ‘void Nes::Core::Boards::Mmc5::SwapPrg8Ex(Nes::uint) [with unsigned int ADDRESS = 8192; Nes::uint = unsigned int]’:
../source/core/board/NstBoardMmc5.cpp:753:48:   required from here
../source/core/board/NstBoardMmc5.cpp:716:38: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
../source/core/board/NstBoardMmc5.cpp: In instantiation of ‘void Nes::Core::Boards::Mmc5::SwapPrg8Ex(Nes::uint) [with unsigned int ADDRESS = 16384; Nes::uint = unsigned int]’:
../source/core/board/NstBoardMmc5.cpp:761:40:   required from here
../source/core/board/NstBoardMmc5.cpp:716:38: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]


g++ -c -o ../source/core/board/NstBoardSachenSa72008.o ../source/core/board/NstBoardSachenSa72008.cpp -DGIT_VERSION=\"" 9fa43cb"\" -Wparentheses -O3 -std=gnu++98 -fPIC -D__LIBRETRO__  -Wno-deprecated -Wno-write-strings  -DNST_NO_ZLIB -I../libretro  -I.. -fno-rtti -I.. -I../source
../source/core/board/NstBoardSachenS8259.cpp: In member function ‘void Nes::Core::Boards::Sachen::S8259::Poke_M_4101(Nes::Core::Address, Nes::Core::Data)’:
../source/core/board/NstBoardSachenS8259.cpp:145:43: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
           (regs[(regs[7] & 0x1U) ? 0 : 0] & 0x07U | h) << s,
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
../source/core/board/NstBoardSachenS8259.cpp:146:43: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
           (regs[(regs[7] & 0x1U) ? 0 : 1] & 0x07U | h) << s | (board != Type::SACHEN_8259B ? 1 : 0),
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
../source/core/board/NstBoardSachenS8259.cpp:147:43: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
           (regs[(regs[7] & 0x1U) ? 0 : 2] & 0x07U | h) << s | (board == Type::SACHEN_8259C ? 2 : 0),
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
../source/core/board/NstBoardSachenS8259.cpp:148:43: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
           (regs[(regs[7] & 0x1U) ? 0 : 3] & 0x07U | h) << s | (board == Type::SACHEN_8259A ? 1 : board == Type::SACHEN_8259C ? 3 : 0)
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~


g++ -c -o ../source/core/board/NstBoardSunsoft1.o ../source/core/board/NstBoardSunsoft1.cpp -DGIT_VERSION=\"" 9fa43cb"\" -Wparentheses -O3 -std=gnu++98 -fPIC -D__LIBRETRO__  -Wno-deprecated -Wno-write-strings  -DNST_NO_ZLIB -I../libretro  -I.. -fno-rtti -I.. -I../source
../source/core/board/NstBoardSachenStreetHeroes.cpp: In member function ‘virtual void Nes::Core::Boards::Sachen::StreetHeroes::UpdateChr(Nes::uint, Nes::uint) cons ’:
../source/core/board/NstBoardSachenStreetHeroes.cpp:154:12: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]

                 ~~~~~~~~~

        ~~   

         ~~~~~~~~~~~~~~~~~~~~~~~

         ~~~~~~~~~~~~~~~~~~~~~~~

         ~~~~~~~~~~~~~~~~~~~~~~~~~
        )   & 0x100 | bank
        ~~~~^~~~~~~


g++ -c -o ../source/core/board/NstBoardSuperGameBoogerman.o ../source/core/board/NstBoardSuperGameBoogerman.cpp -DGIT_VERSION=\"" 9fa43cb"\" -Wparentheses -O3 -std=gnu++98 -fPIC -D__LIBRETRO__  -Wno-deprecated -Wno-write-strings  -DNST_NO_ZLIB -I../libretro  -I.. -fno-rtti -I.. -I../source
../source/core/board/NstBoardSunsoftDcs.cpp: In member function ‘Nes::Core::Data Nes::Core::Boards::Sunsoft::Dcs::Peek_M_8000(Nes::Core::Address)’:
../source/core/board/NstBoardSunsoftDcs.cpp:99:99: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
 (prgBank & 0x8 && counter < SIGNAL && ++counter == SIGNAL) ? (prgBank & 0x7 | 0x10) : 0))
                                                               ~~~~~~~~^~~~~


g++ -c -o ../source/core/input/NstInpBandaiHyperShot.o ../source/core/input/NstInpBandaiHyperShot.cpp -DGIT_VERSION=\"" 9fa43cb"\" -Wparentheses -O3 -std=gnu++98 -fPIC -D__LIBRETRO__  -Wno-deprecated -Wno-write-strings  -DNST_NO_ZLIB -I../libretro  -I.. -fno-rtti -I.. -I../source
../source/core/board/NstBoardWaixingSh2.cpp: In member function ‘virtual void Nes::Core::Boards::Waixing::Sh2::SubLoad(Nes::Core::State::Loader&, Nes::dword)’:
../source/core/board/NstBoardWaixingSh2.cpp:66:28: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
         selector[1] = data & 0x2 | 0x4;
                       ~~~~~^~~~~


g++ -c -o ../libretro/libretro.o ../libretro/libretro.cpp -DGIT_VERSION=\"" 9fa43cb"\" -Wparentheses -O3 -std=gnu++98 -fPIC -D__LIBRETRO__  -Wno-deprecated -Wno-write-strings  -DNST_NO_ZLIB -I../libretro  -I.. -fno-rtti -I.. -I../source
../source/core/vssystem/NstVsSystem.cpp: In member function ‘Nes::Core::Data Nes::Core::Cartridge::VsSystem::Peek_M_4016(Nes::Core::Address)’:
../source/core/vssystem/NstVsSystem.cpp:1475:47: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
    return dips.Reg(0) | p4016.Peek( address ) & (STATUS_4016_MASK^0xFFU);
                         ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
../source/core/vssystem/NstVsSystem.cpp: In member function ‘Nes::Core::Data Nes::Core::Cartridge::VsSystem::Peek_M_4017(Nes::Core::Address)’:
../source/core/vssystem/NstVsSystem.cpp:1485:47: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
    return dips.Reg(1) | p4017.Peek( address ) & (STATUS_4017_MASK^0xFFU);
                         ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~


g++ -c -o ../source/core/board/NstBoardBmcSuper22Games.o ../source/core/board/NstBoardBmcSuper22Games.cpp -DGIT_VERSION=\"" 9d6e5c2"\" -Wparentheses -O3 -std=gnu++98 -fPIC -D__LIBRETRO__  -Wno-deprecated -Wno-write-strings  -DNST_NO_ZLIB -I../libretro  -I.. -fno-rtti -I.. -I../source
../source/core/board/NstBoardBmcPowerjoy84in1.cpp: In member function ‘virtual void Nes::Core::Boards::Bmc::Powerjoy84in1::UpdatePrg(Nes::uint, Nes::uint)’:
../source/core/board/NstBoardBmcPowerjoy84in1.cpp:101:36: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
      bank &= ~uint(exRegs[0]) >> 2 & 0x10 | 0x0F;
              ~~~~~~~~~~~~~~~~~~~~~~^~~~~~
```