### PR TITLE
(libretro) Include libretro.h

### DIFF
--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -587,7 +587,7 @@ DEFINES := -D__LIBRETRO__ $(PLATFORM_DEFINES) $(GCC_FLAGS) $(GCC_WARNINGS) -DNST
 CFLAGS += $(fpic) $(DEFINES) $(C_VER)
 CXXFLAGS += $(fpic) $(DEFINES)
 
-INCDIRS := -I$(CORE_DIR) -I$(CORE_DIR)/source -I$(LIBRETRO_DIR)/libretro-common/include
+INCDIRS := -I$(CORE_DIR) -I$(CORE_DIR)/source
 
 OBJOUT   = -o
 LINKOUT  = -o 

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -1,5 +1,5 @@
 LIBRETRO_COMM_DIR := $(CORE_DIR)/libretro/libretro-common
-INCFLAGS := -I$(CORE_DIR)/libretro  -I$(CORE_DIR)
+INCFLAGS := -I$(CORE_DIR)/libretro  -I$(CORE_DIR) -I$(LIBRETRO_COMM_DIR)/include
 
 ifneq (,$(findstring msvc2003,$(platform)))
 INCFLAGS += -I$(LIBRETRO_COMM_DIR)/include/compat/msvc


### PR DESCRIPTION
Fixes the following build error since `libretro.h` is now in `libretro-common`.
```
../libretro/libretro.cpp:1:10: fatal error: libretro.h: No such file or directory
 #include "libretro.h"
          ^~~~~~~~~~~~
compilation terminated.
make: *** [Makefile:625: ../libretro/libretro.o] Error 1
make: Leaving directory '/tmp/SBo/nestopia-libretro/libretro'
```