### PR TITLE
 4 Player Adapter + NstDatabase.xml

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -366,6 +366,7 @@ void retro_set_environment(retro_environment_t cb)
       { "nestopia_palette", "Palette; cxa2025as|consumer|canonical|alternative|rgb|pal|composite-direct-fbx|pvm-style-d93-fbx|ntsc-hardware-fbx|nes-classic-fbx-fs|raw|custom" },
       { "nestopia_nospritelimit", "Remove 8-sprites-per-scanline hardware limit; disabled|enabled" },
       { "nestopia_overclock", "CPU Speed (Overclock); 1x|2x" },
+	  { "nestopia_select_adapter", "4 Player Adapter; auto|ntsc|famicom" },
       { "nestopia_fds_auto_insert", "Automatically insert first FDS disk on reset; enabled|disabled" },
       { "nestopia_overscan_v", "Mask Overscan (Vertical); enabled|disabled" },
       { "nestopia_overscan_h", "Mask Overscan (Horizontal); disabled|enabled" },
@@ -805,6 +806,21 @@ static void check_variables(void)
        aspect_ratio_mode = 0;
    }
    
+   var.key = "nestopia_select_adapter";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+
+	   if (!strcmp(var.value, "ntsc"))
+		   Api::Input(emulator).ConnectAdapter(Api::Input::ADAPTER_NES);
+	   else if (!strcmp(var.value, "famicom"))
+		   Api::Input(emulator).ConnectAdapter(Api::Input::ADAPTER_FAMICOM);
+	   else
+		   if (dbpresent)
+		   {
+			   Api::Input(emulator).AutoSelectAdapter();
+		   }
+   }
+
    var.key = "nestopia_turbo_pulse";
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -808,17 +808,25 @@ static void check_variables(void)
    
    var.key = "nestopia_select_adapter";
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-
-	   if (!strcmp(var.value, "ntsc"))
-		   Api::Input(emulator).ConnectAdapter(Api::Input::ADAPTER_NES);
-	   else if (!strcmp(var.value, "famicom"))
-		   Api::Input(emulator).ConnectAdapter(Api::Input::ADAPTER_FAMICOM);
-	   else
+   { 
+	   if (!strcmp(var.value, "auto")) {
 		   if (dbpresent)
 		   {
+			   Api::Input(emulator).AutoSelectController(2);
+			   Api::Input(emulator).AutoSelectController(3);
 			   Api::Input(emulator).AutoSelectAdapter();
 		   }
+	   }
+	   else if (!strcmp(var.value, "ntsc")) {
+		   Api::Input(emulator).ConnectController(2, Api::Input::PAD3);
+	       Api::Input(emulator).ConnectController(3, Api::Input::PAD4);
+		   Api::Input(emulator).ConnectAdapter(Api::Input::ADAPTER_NES);
+		}
+	   else if (!strcmp(var.value, "famicom")) {
+		   Api::Input(emulator).ConnectController(2, Api::Input::PAD3);
+		   Api::Input(emulator).ConnectController(3, Api::Input::PAD4);
+		   Api::Input(emulator).ConnectAdapter(Api::Input::ADAPTER_FAMICOM);
+		}
    }
 
    var.key = "nestopia_turbo_pulse";
@@ -1122,17 +1130,12 @@ bool retro_load_game(const struct retro_game_info *info)
    {
       Api::Input(emulator).AutoSelectController(0);
       Api::Input(emulator).AutoSelectController(1);
-      Api::Input(emulator).AutoSelectController(2);
-      Api::Input(emulator).AutoSelectController(3);
-      Api::Input(emulator).AutoSelectAdapter();
    }
    else
    {
       Api::Input(emulator).ConnectController(0, Api::Input::PAD1);
       Api::Input(emulator).ConnectController(1, Api::Input::PAD2);
       //Api::Input(emulator).ConnectController(1, Api::Input::ZAPPER);
-      Api::Input(emulator).ConnectController(2, Api::Input::PAD3);
-      Api::Input(emulator).ConnectController(3, Api::Input::PAD4);
    }
 
    machine->Power(true);


### PR DESCRIPTION
I overlooked the NstDatabase.xml when adding options for users to manually assign adapters. If (dbpresent) is true, it would select the most suited adapter, and would not allow users to manually assign the adapter. I moved some code around, and added a bit, so everything should function correctly now even if NstDatabase.xml is present in system folder or not.