### PR TITLE
fix a symbol not found crash upon loading the core on Haiku

### DIFF
--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -53,6 +53,9 @@ ifeq ($(platform), unix)
 	TARGET := $(TARGET_NAME)_libretro.so
 	fpic := -fPIC
 	SHARED := -shared -Wl,-version-script=link.T -Wl,-no-undefined
+ifeq ($(shell uname -s), Haiku)
+	LDFLAGS += -lroot
+endif
 
 # OS X
 else ifeq ($(platform), osx)


### PR DESCRIPTION
Without this, the core crashes with the following message:
```
resolve symbol "_ZTSSt9exception" returned: -2147478780
```
It's quite a fun one because strace shows:
```
[  4779] _kern_debug_output("runtime_loader: /boot/system/add-ons/libretro/nestopia_libretro.so: Found symbol '_ZTSSt9exception', but not exported
") (2082 us)
resolve symbol "_ZTSSt9exception" returned: -2147478780
[  4779] _kern_write(0x2, 0x0, 0x7f7e297cd330, 0x38) = 0x38 (8 us)
[  4779] _kern_debug_output("runtime_loader: /boot/system/add-ons/libretro/nestopia_libretro.so: Troubles relocating: Symbol not found
") (1712 us)
```
So I don't even know how linking succeeded before. 
But with this patch now the crash is gone \o/