### PR TITLE
added Show Advanced Audio Settings core option

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -63,6 +63,7 @@ static bool overscan_h;
 static unsigned aspect_ratio_mode;
 static unsigned tpulse;
 static bool libretro_supports_bitmasks = false;
+static bool show_advanced_av_settings = true;
 
 int16_t video_width = Api::Video::Output::WIDTH;
 size_t pitch;
@@ -1023,12 +1024,53 @@ static void check_variables(void)
       sound.SetVolume(Api::Sound::CHANNEL_N163, atoi(var.value));
    }
    
-   var.key = "nestopia_audio_vol_s5B";
+   var.key = "nestopia_audio_vol_s5b";
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       sound.SetVolume(Api::Sound::CHANNEL_S5B, atoi(var.value));
    }   
+   
+
+  var.key = "nestopia_show_advanced_av_settings";
+  
+  var.value = NULL;
+  if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+  {
+    bool show_advanced_av_settings_prev = show_advanced_av_settings;
+
+    show_advanced_av_settings = true;
+    if (strcmp(var.value, "disabled") == 0)
+      show_advanced_av_settings = false;
+
+    if (show_advanced_av_settings != show_advanced_av_settings_prev)
+    {
+      size_t i;
+      struct retro_core_option_display option_display;
+      char av_keys[11][40] = {
+        "nestopia_audio_vol_sq1",
+        "nestopia_audio_vol_sq2",
+        "nestopia_audio_vol_tri",
+        "nestopia_audio_vol_noise",
+        "nestopia_audio_vol_dpcm",
+        "nestopia_audio_vol_fds",
+        "nestopia_audio_vol_mmc5",
+        "nestopia_audio_vol_vrc6",
+        "nestopia_audio_vol_vrc7",
+        "nestopia_audio_vol_n163",
+        "nestopia_audio_vol_s5b"
+      };
+
+      option_display.visible = show_advanced_av_settings;
+
+      for (i = 0; i < 11; i++)
+      {
+        option_display.key = av_keys[i];
+        environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+      }
+    }
+  }
+  
 }
 
 void retro_run(void)

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -230,9 +230,20 @@ struct retro_core_option_definition option_defs_us[] = {
       "2"
    },
    {
+      "nestopia_show_advanced_av_settings",
+      "Show Advanced Audio Settings (Reopen menu)",
+      "Enable configuration of low-level audio channel parameters.",
+      {
+         { "enabled",  NULL },
+         { "disabled", NULL },
+         { NULL, NULL},
+      },
+      "disabled"
+   },
+   {
       "nestopia_audio_vol_sq1",
       "Square 1 Channel Volume %",
-      "Modify Square 1 Channel Volume  %.",
+      "Modify Square 1 Channel Volume %.",
       {
          { "0", NULL },
          { "10", NULL },
@@ -254,7 +265,7 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "nestopia_audio_vol_sq2",
       "Square 2 Channel Volume %",
-      "Modify Square 2 Channel Volume  %.",
+      "Modify Square 2 Channel Volume %.",
       {
          { "0", NULL },
          { "10", NULL },
@@ -276,7 +287,7 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "nestopia_audio_vol_tri",
       "Triangle Channel Volume %",
-      "Modify Triangle Channel Volume  %.",
+      "Modify Triangle Channel Volume %.",
       {
          { "0", NULL },
          { "10", NULL },
@@ -298,7 +309,7 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "nestopia_audio_vol_noise",
       "Noise Channel Volume %",
-      "Modify Noise Channel Volume  %.",
+      "Modify Noise Channel Volume %.",
       {
          { "0", NULL },
          { "10", NULL },
@@ -320,7 +331,7 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "nestopia_audio_vol_dpcm",
       "DPCM Channel Volume %",
-      "Modify DPCM Channel Volume  %.",
+      "Modify DPCM Channel Volume %.",
       {
          { "0", NULL },
          { "10", NULL },
@@ -342,7 +353,7 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "nestopia_audio_vol_fds",
       "FDS Channel Volume %",
-      "Modify FDS Channel Volume  %.",
+      "Modify FDS Channel Volume %.",
       {
          { "0", NULL },
          { "10", NULL },
@@ -364,7 +375,7 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "nestopia_audio_vol_mmc5",
       "MMC5 Channel Volume %",
-      "Modify MMC5 Channel Volume  %.",
+      "Modify MMC5 Channel Volume %.",
       {
          { "0", NULL },
          { "10", NULL },
@@ -386,7 +397,7 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "nestopia_audio_vol_vrc6",
       "VRC6 Channel Volume %",
-      "Modify VRC6 Channel Volume  %.",
+      "Modify VRC6 Channel Volume %.",
       {
          { "0", NULL },
          { "10", NULL },
@@ -408,7 +419,7 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "nestopia_audio_vol_vrc7",
       "VRC7 Channel Volume %",
-      "Modify VRC7 Channel Volume  %.",
+      "Modify VRC7 Channel Volume %.",
       {
          { "0", NULL },
          { "10", NULL },
@@ -430,7 +441,7 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "nestopia_audio_vol_n163",
       "N163 Channel Volume %",
-      "Modify N163 Channel Volume  %.",
+      "Modify N163 Channel Volume %.",
       {
          { "0", NULL },
          { "10", NULL },
@@ -450,9 +461,9 @@ struct retro_core_option_definition option_defs_us[] = {
       "100"
    },
    {
-      "nestopia_audio_vol_s5B",
+      "nestopia_audio_vol_s5b",
       "S5B Channel Volume %",
-      "Modify N163 Channel Volume  %.",
+      "Modify N163 Channel Volume %.",
       {
          { "0", NULL },
          { "10", NULL },


### PR DESCRIPTION
This reduces the cluttering in the core options after https://github.com/libretro/nestopia/pull/15.

Could be reused with switches to toggle the GFX layers.