### PR TITLE
Updated the Zapper code

### DIFF
--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -213,6 +213,18 @@ struct retro_core_option_definition option_defs_us[] = {
       "disabled"
    },
    {
+      "nestopia_zapper_device",
+      "Zapper device",
+      "Select the device you wish to use for the Zapper.",
+      {
+         { "lightgun", NULL },
+         { "mouse", NULL },
+         { "pointer", NULL },
+         { NULL, NULL },
+      },
+      "lightgun",
+   },
+   {
       "nestopia_turbo_pulse",
       "Turbo Pulse Speed",
       "Set the turbo pulse speed for the Turbo B and Turbo A buttons.",


### PR DESCRIPTION
I noticed that the Nestopia Zapper code used the deprecated RETRO_DEVICE_ID_LIGHTGUN_{X,Y} constants, so I updated the code to use RETRO_DEVICE_ID_LIGHTGUN_SCREEN_{X,Y}.  I also added code for the pointer and mouse device types.