### PR TITLE
Update database

### DIFF
--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -763,7 +763,7 @@ include $(THEOS_MAKE_PATH)/library.mk
 else
 all: $(TARGET)
 
-$(TARGET): $(OBJECTS) nstdatabase.hpp
+$(TARGET): nstdatabase.hpp $(OBJECTS)
 ifeq ($(STATIC_LINKING), 1)
 	$(AR) rcs $@ $(OBJECTS)
 else
@@ -779,6 +779,7 @@ endif
 PYTHON ?= python
 nstdatabase.hpp: ../NstDatabase.xml
 	-$(PYTHON) xml2hpp.py $< $@
+	rm -f libretro.o
 
 clean-objs:
 	rm -f $(OBJECTS)

--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -763,7 +763,7 @@ include $(THEOS_MAKE_PATH)/library.mk
 else
 all: $(TARGET)
 
-$(TARGET): $(OBJECTS)
+$(TARGET): $(OBJECTS) nstdatabase.hpp
 ifeq ($(STATIC_LINKING), 1)
 	$(AR) rcs $@ $(OBJECTS)
 else
@@ -775,6 +775,10 @@ endif
 
 %.o: %.c
 	$(CC) $(CPPFLAGS) -c $(OBJOUT)$@ $< $(CFLAGS) $(INCDIRS)
+
+PYTHON ?= python
+nstdatabase.hpp: ../NstDatabase.xml
+	-$(PYTHON) xml2hpp.py $< $@
 
 clean-objs:
 	rm -f $(OBJECTS)

--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -763,7 +763,7 @@ include $(THEOS_MAKE_PATH)/library.mk
 else
 all: $(TARGET)
 
-$(TARGET): nstdatabase.hpp $(OBJECTS)
+$(TARGET): $(OBJECTS)
 ifeq ($(STATIC_LINKING), 1)
 	$(AR) rcs $@ $(OBJECTS)
 else

--- a/libretro/xml2hpp.py
+++ b/libretro/xml2hpp.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+# A Python script to convert NstDatabase.xml to a file that can be baked into
+# the Nestopia core, so that users won't have to maintain NstDatabase.xml in
+# their system directory.
+#
+# Licensed under the same license as Nestopia UE.
+
+import sys
+if len(sys.argv) > 1:
+    in_file = sys.argv[1]
+else:
+    in_file = "../NstDatabase.xml"
+
+if len(sys.argv) > 2:
+    out_file = sys.argv[2]
+else:
+    out_file = "nstdatabase.hpp"
+
+f1 = open(in_file, "r")
+f2 = open(out_file, "w")
+f2.write("const unsigned char nst_db_xml[] = {\n\t")
+
+while (s := f1.read(1).encode("utf-8")) != b'':
+    # Handle multibyte characters
+    for i in range(0, len(s)):
+        f2.write("0x%x, " % s[i])
+
+f2.write("\n};\n")
+f1.close()
+f2.close()


### PR DESCRIPTION
This was my original idea before R Danbrook said that the baked-in database should be reverted.  It's a Python script to generate a new nstdatabase.hpp file whenever NstDatabase.xml is updated.  The nstdatabase.hpp file has been updated from 1.51.0's NstDatabase.xml with the script (as R Danbrook's PR didn't update the nstdatabase.hpp file).  It can also be used by users to convert their altered NstDatabase.xml files to a header that can be compiled into Nestopia (they'll have to recompile the core to use the database, but that's better than nothing; however, that might be the only way if what they need to override isn't available from the UI).