### PR TITLE
Add more 4/8px cropping for top and bottom

### DIFF
--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -171,6 +171,8 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { "8",  NULL },
          { "12",  NULL },
          { "16",  NULL },
+         { "20",  NULL },
+         { "24",  NULL },
          { NULL, NULL },
       },
       "8"
@@ -188,6 +190,8 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { "8",  NULL },
          { "12",  NULL },
          { "16",  NULL },
+         { "20",  NULL },
+         { "24",  NULL },
          { NULL, NULL },
       },
       "8"


### PR DESCRIPTION
Many games require more cropping to remove black borders

Bucky O'Hare (USA) 20px bottom:
![224976466-5b20cad2-045b-4a11-a237-1c9d01d47c6e](https://user-images.githubusercontent.com/80488411/228189204-6d4b5d0f-3f3e-4c77-b3b4-9bcb71570e1a.png)

2010 Street Fighter 24px bottom:
![224976634-67db60b6-82f4-400b-bec4-162f2438916c](https://user-images.githubusercontent.com/80488411/228189262-d9d61984-85ce-4a2c-9649-417169ab9133.png)

 according to my experience, the left and right crops do not need more pixels, so maintaining the original maximum of 16 is ok