### PR TITLE
limit paddle range to the actual values sent by the controllers

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -63,6 +63,8 @@ static char *g_save_dir;
 static char samp_dir[256];
 static unsigned blargg_ntsc;
 static bool fds_auto_insert;
+static int arkanoid_paddle_min = 0;
+static int arkanoid_paddle_max = 255;
 static int overscan_v_top, overscan_v_bottom;
 static int overscan_h_left, overscan_h_right;
 static bool libretro_supports_option_categories = false;
@@ -743,6 +745,8 @@ static bool NST_CALLBACK arkanoid_callback(Api::Base::UserData data, Core::Input
    switch (arkanoid_device)
    {
       case ARKANOID_DEVICE_MOUSE:
+         min_x = arkanoid_paddle_min;
+         max_x = arkanoid_paddle_max;
          cur_x += input_state_cb(1, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_X);
          button = input_state_cb(1, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_LEFT);
          break;
@@ -1231,6 +1235,24 @@ static void check_variables(void)
       }
    }
    
+   // https://www.nesdev.org/wiki/Arkanoid_controller
+   // There are two different Arkanoid (or Vaus) controllers.
+   // And each controller has a slightly different range of values.
+   var.key = "nestopia_arkanoid_paddle_range";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var)) {
+      // Default full range that will work for both arkanoidI and arkanoidII
+      arkanoid_paddle_min = 32;
+      arkanoid_paddle_max = 166;   
+      if (strcmp(var.value, "arkanoidI") == 0) {
+         arkanoid_paddle_min = 46;
+         arkanoid_paddle_max = 166;   
+      }
+      else if (strcmp(var.value, "arkanoidII") == 0) {
+         arkanoid_paddle_min = 32;
+         arkanoid_paddle_max = 153;   
+      }
+   }
+
    var.key = "nestopia_overscan_v_top";
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var)) {

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -613,6 +613,20 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "mouse"
    },
    {
+      "nestopia_arkanoid_paddle_range",
+      "Arkanoid Paddle Range",
+      NULL,
+      "Set the range for the Arkanoid paddle.",
+      NULL,
+      "input",
+      {
+         { "combined", "Combined range of both controllers (32-166)"},
+         { "arkanoidI", "Arkanoid I controller range (46-166)"},
+         { "arkanoidII", "Arkanoid II controller range (32-153)"}
+      },
+      "combined"
+   },
+   {
       "nestopia_zapper_device",
       "Zapper device",
       NULL,


### PR DESCRIPTION
Add options for the range so users can match it exactly to the game.

This default combined paddle range reduces the "dead" spots. The specific controller ranges eliminates the "dead" spots completely. By dead spots I mean when the paddle position is far to the right or left and moving the mouse seems to have no effect. 

This range only applies when the "Core Options/Input/Arkanoid device" is set to "Mouse". Using a range like this doesn't make much sense with the "Pointer" option. To be accurate with the pointer we'd need to know both the range of the controller, and also the pixel range in the game that this controller range covers. That way the absolute pointer position could line up with the paddle on the screen. This could be useful for someone playing on a touch screen, but I don't plan on working on that.

I am planning to add an analog stick option for the Arkanoid device. The analog stick could be absolute or relative. The range work helps with this because in absolute mode the center of the analog stick can be in the center of the range. And with relative motion the dead spots would be pretty annoying.