### PR TITLE
Add "1" option on "Turbo Pulse Speed" option

### DIFF
--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -665,6 +665,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       NULL,
       "input",
       {
+         { "1", NULL },
          { "2", NULL },
          { "3", NULL },
          { "4", NULL },


### PR DESCRIPTION
Currently there's no option in "Turbo Pulse Speed" for set it to "1", but it's nice to have it.
So i added "1" as an option for Turbo Pulse Speed.

Tested on a few games (including Track & Field, Star Soldier, etc.) and working.