### PR TITLE
Libretro: Refactor check_variables() in libretro.cpp with core option reordering

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1008,48 +1008,10 @@ static void check_variables(void)
    Api::Machine machine(emulator);
    Api::Video::RenderState::Filter filter;
 
-   var.key = "nestopia_arkanoid_device";
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
-   {
-      if (strcmp(var.value, "mouse") == 0)
-         arkanoid_device = ARKANOID_DEVICE_MOUSE;
-      if (strcmp(var.value, "pointer") == 0)
-         arkanoid_device = ARKANOID_DEVICE_POINTER;
-   }
+   /* System */
 
-   var.key = "nestopia_zapper_device";
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
-   {
-      if (strcmp(var.value, "lightgun") == 0)
-         zapper_device = ZAPPER_DEVICE_LIGHTGUN;
-      else if (strcmp(var.value, "mouse") == 0)
-         zapper_device = ZAPPER_DEVICE_MOUSE;
-      else if (strcmp(var.value, "pointer") == 0)
-         zapper_device = ZAPPER_DEVICE_POINTER;
-   }
-
-   var.key = "nestopia_show_crosshair";
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
-   {
-      if (strcmp(var.value, "disabled") == 0)
-         show_crosshair = SHOW_CROSSHAIR_DISABLED;
-      else
-         show_crosshair = SHOW_CROSSHAIR_OFF;
-   }
-
-   var.key = "nestopia_button_shift";
-   
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
-   {
-      if (strcmp(var.value, "disabled") == 0)
-         bindmap = bindmap_default;
-      else if (strcmp(var.value, "enabled") == 0)
-         bindmap = bindmap_shifted;
-   }
-   
    var.key = "nestopia_favored_system";
    is_pal = false;
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
    {
       if (strcmp(var.value, "auto") == 0)
@@ -1098,55 +1060,11 @@ static void check_variables(void)
    if (audio) delete audio;
    audio = new Api::Sound::Output(audio_buffer, is_pal ? SAMPLERATE / 50 : SAMPLERATE / 60);
 
-   var.key = "nestopia_genie_distortion";
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
-   {
-      if (strcmp(var.value, "disabled") == 0)
-         sound.SetGenie(0);
-      else if (strcmp(var.value, "enabled") == 0)
-         sound.SetGenie(1);
-   }
-   
-   var.key = "nestopia_ram_power_state";
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
-   {
-      if (strcmp(var.value, "0x00") == 0)
-         machine.SetRamPowerState(0);
-      else if (strcmp(var.value, "0xFF") == 0)
-         machine.SetRamPowerState(1);
-      else if (strcmp(var.value, "random") == 0)
-         machine.SetRamPowerState(2);
-   }
-
-   var.key = "nestopia_nospritelimit";
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
-   {
-      if (strcmp(var.value, "disabled") == 0)
-         video.EnableUnlimSprites(false);
-      else if (strcmp(var.value, "enabled") == 0)
-         video.EnableUnlimSprites(true);
-   }
-   
-   var.key = "nestopia_overclock";
-   
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
-   {
-      if (strcmp(var.value, "1x") == 0)
-         video.EnableOverclocking(false);
-      else if (strcmp(var.value, "2x") == 0)
-         video.EnableOverclocking(true);
-   }
-   
    var.key = "nestopia_fds_auto_insert";
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
       fds_auto_insert = (strcmp(var.value, "enabled") == 0);
 
    var.key = "nestopia_fds_savefile_format";
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
    {
       if (strcmp(var.value, "sav_ups") == 0)
@@ -1166,8 +1084,9 @@ static void check_variables(void)
       fds_patch_format_ips = (fds_savefile_format == FDS_SAVEFILE_IPS);
    }
 
-   var.key = "nestopia_blargg_ntsc_filter";
+   /* Video */
 
+   var.key = "nestopia_blargg_ntsc_filter";
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
    {
       if (strcmp(var.value, "disabled") == 0)
@@ -1230,9 +1149,8 @@ static void check_variables(void)
          video_width = Api::Video::Output::NTSC_WIDTH;
          break;
    }
-   
+
    var.key = "nestopia_palette";
-   
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
    {
       if (strcmp(var.value, "consumer") == 0) {
@@ -1314,68 +1232,154 @@ static void check_variables(void)
          video.GetPalette().SetCustom((const byte(*)[3])custpal, Api::Video::Palette::STD_PALETTE);
       }
    }
-   
-   // https://www.nesdev.org/wiki/Arkanoid_controller
-   // There are two different Arkanoid (or Vaus) controllers.
-   // And each controller has a slightly different range of values.
-   var.key = "nestopia_arkanoid_paddle_range";
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var)) {
-      // Default full range that will work for both arkanoidI and arkanoidII
-      arkanoid_paddle_min = 32;
-      arkanoid_paddle_max = 166;   
-      if (strcmp(var.value, "arkanoidI") == 0) {
-         arkanoid_paddle_min = 46;
-         arkanoid_paddle_max = 166;   
-      }
-      else if (strcmp(var.value, "arkanoidII") == 0) {
-         arkanoid_paddle_min = 32;
-         arkanoid_paddle_max = 153;   
-      }
-   }
 
    var.key = "nestopia_overscan_v_top";
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var)) {
       overscan_v_top = atoi(var.value);
    }
 
    var.key = "nestopia_overscan_v_bottom";
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var)) {
       overscan_v_bottom = atoi(var.value);
    }
 
    var.key = "nestopia_overscan_h_left";
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var)) {
       overscan_h_left = atoi(var.value);
    }
 
    var.key = "nestopia_overscan_h_right";
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var)) {
       overscan_h_right = atoi(var.value);
    }
 
    var.key = "nestopia_aspect";
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-     if (!strcmp(var.value, "ntsc"))
-       aspect_ratio_mode = 1;
-     else if (!strcmp(var.value, "pal"))
-       aspect_ratio_mode = 2;
-     else if (!strcmp(var.value, "4:3"))
-       aspect_ratio_mode = 3;
-     else if (!strcmp(var.value, "uncorrected"))
-       aspect_ratio_mode = 4;
-     else
-       aspect_ratio_mode = 0;
+      if (!strcmp(var.value, "ntsc"))
+         aspect_ratio_mode = 1;
+      else if (!strcmp(var.value, "pal"))
+         aspect_ratio_mode = 2;
+      else if (!strcmp(var.value, "4:3"))
+         aspect_ratio_mode = 3;
+      else if (!strcmp(var.value, "uncorrected"))
+         aspect_ratio_mode = 4;
+      else
+         aspect_ratio_mode = 0;
    }
-   
+
+   /* Audio */
+
+   var.key = "nestopia_genie_distortion";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
+   {
+      if (strcmp(var.value, "disabled") == 0)
+         sound.SetGenie(0);
+      else if (strcmp(var.value, "enabled") == 0)
+         sound.SetGenie(1);
+   }
+
+   /* "Show settings" are not required if categories are supported */
+   option_display.visible = !libretro_supports_option_categories;
+   option_display.key = "nestopia_show_advanced_av_settings";
+   environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+
+   var.key = "nestopia_show_advanced_av_settings";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      bool show_advanced_av_settings_prev = show_advanced_av_settings;
+
+      show_advanced_av_settings = true;
+      if (strcmp(var.value, "disabled") == 0)
+         show_advanced_av_settings = false;
+
+      if (show_advanced_av_settings != show_advanced_av_settings_prev)
+      {
+         size_t i;
+         char av_keys[11][40] = {
+         "nestopia_audio_vol_sq1",
+         "nestopia_audio_vol_sq2",
+         "nestopia_audio_vol_tri",
+         "nestopia_audio_vol_noise",
+         "nestopia_audio_vol_dpcm",
+         "nestopia_audio_vol_fds",
+         "nestopia_audio_vol_mmc5",
+         "nestopia_audio_vol_vrc6",
+         "nestopia_audio_vol_vrc7",
+         "nestopia_audio_vol_n163",
+         "nestopia_audio_vol_s5b"
+         };
+
+         option_display.visible = show_advanced_av_settings
+                                 || libretro_supports_option_categories;
+
+         for (i = 0; i < 11; i++)
+         {
+         option_display.key = av_keys[i];
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+         }
+      }
+   }
+
+   var.key = "nestopia_audio_vol_sq1";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+      sound.SetVolume(Api::Sound::CHANNEL_SQUARE1, atoi(var.value));
+
+   var.key = "nestopia_audio_vol_sq2";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+      sound.SetVolume(Api::Sound::CHANNEL_SQUARE2, atoi(var.value));
+
+   var.key = "nestopia_audio_vol_tri";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+      sound.SetVolume(Api::Sound::CHANNEL_TRIANGLE, atoi(var.value));
+
+   var.key = "nestopia_audio_vol_noise";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+      sound.SetVolume(Api::Sound::CHANNEL_NOISE, atoi(var.value));
+
+   var.key = "nestopia_audio_vol_dpcm";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+      sound.SetVolume(Api::Sound::CHANNEL_DPCM, atoi(var.value));
+
+   var.key = "nestopia_audio_vol_fds";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+      sound.SetVolume(Api::Sound::CHANNEL_FDS, atoi(var.value));
+
+   var.key = "nestopia_audio_vol_mmc5";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+      sound.SetVolume(Api::Sound::CHANNEL_MMC5, atoi(var.value));
+
+   var.key = "nestopia_audio_vol_vrc6";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+      sound.SetVolume(Api::Sound::CHANNEL_VRC6, atoi(var.value));
+
+   var.key = "nestopia_audio_vol_vrc7";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+      sound.SetVolume(Api::Sound::CHANNEL_VRC7, atoi(var.value));
+
+   var.key = "nestopia_audio_vol_n163";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+      sound.SetVolume(Api::Sound::CHANNEL_N163, atoi(var.value));
+
+   var.key = "nestopia_audio_vol_s5b";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+      sound.SetVolume(Api::Sound::CHANNEL_S5B, atoi(var.value));
+
+   var.key = "nestopia_audio_type";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
+   {
+      if (strcmp(var.value, "mono") == 0)
+         sound.SetSpeaker(Api::Sound::SPEAKER_MONO);
+      else
+         sound.SetSpeaker(Api::Sound::SPEAKER_STEREO);
+   }
+
+   /* Input */
+
    var.key = "nestopia_select_adapter";
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   { 
+   {
        if (!strcmp(var.value, "auto")) {
            Api::Input(emulator).AutoSelectAdapter();
        }
@@ -1387,13 +1391,71 @@ static void check_variables(void)
         }
    }
 
-   var.key = "nestopia_turbo_pulse";
+   var.key = "nestopia_button_shift";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
+   {
+      if (strcmp(var.value, "disabled") == 0)
+         bindmap = bindmap_default;
+      else if (strcmp(var.value, "enabled") == 0)
+         bindmap = bindmap_shifted;
+   }
 
+   var.key = "nestopia_arkanoid_device";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
+   {
+      if (strcmp(var.value, "mouse") == 0)
+         arkanoid_device = ARKANOID_DEVICE_MOUSE;
+      if (strcmp(var.value, "pointer") == 0)
+         arkanoid_device = ARKANOID_DEVICE_POINTER;
+   }
+
+   // https://www.nesdev.org/wiki/Arkanoid_controller
+   // There are two different Arkanoid (or Vaus) controllers.
+   // And each controller has a slightly different range of values.
+   var.key = "nestopia_arkanoid_paddle_range";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
+   {
+      // Default full range that will work for both arkanoidI and arkanoidII
+      arkanoid_paddle_min = 32;
+      arkanoid_paddle_max = 166;
+      if (strcmp(var.value, "arkanoidI") == 0)
+      {
+         arkanoid_paddle_min = 46;
+         arkanoid_paddle_max = 166;
+      }
+      else if (strcmp(var.value, "arkanoidII") == 0)
+      {
+         arkanoid_paddle_min = 32;
+         arkanoid_paddle_max = 153;
+      }
+   }
+
+   var.key = "nestopia_zapper_device";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
+   {
+      if (strcmp(var.value, "lightgun") == 0)
+         zapper_device = ZAPPER_DEVICE_LIGHTGUN;
+      else if (strcmp(var.value, "mouse") == 0)
+         zapper_device = ZAPPER_DEVICE_MOUSE;
+      else if (strcmp(var.value, "pointer") == 0)
+         zapper_device = ZAPPER_DEVICE_POINTER;
+   }
+
+   var.key = "nestopia_show_crosshair";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
+   {
+      if (strcmp(var.value, "disabled") == 0)
+         show_crosshair = SHOW_CROSSHAIR_DISABLED;
+      else
+         show_crosshair = SHOW_CROSSHAIR_OFF;
+   }
+
+   var.key = "nestopia_turbo_pulse";
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
       tpulse = atoi(var.value);
-   
+
    pitch = video_width * 4;
-   
+
    renderState.filter = filter;
    renderState.width = video_width;
    renderState.height = Api::Video::Output::HEIGHT;
@@ -1407,140 +1469,37 @@ static void check_variables(void)
    retro_get_system_av_info(&av_info);
    environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &av_info);
 
-   var.key = "nestopia_audio_vol_sq1";
+   /* Emulation Hacks */
 
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      sound.SetVolume(Api::Sound::CHANNEL_SQUARE1, atoi(var.value));
-   }
-
-   var.key = "nestopia_audio_vol_sq2";
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      sound.SetVolume(Api::Sound::CHANNEL_SQUARE2, atoi(var.value));
-   }
-   
-   var.key = "nestopia_audio_vol_tri";
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      sound.SetVolume(Api::Sound::CHANNEL_TRIANGLE, atoi(var.value));
-   }
-   
-   var.key = "nestopia_audio_vol_noise";
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      sound.SetVolume(Api::Sound::CHANNEL_NOISE, atoi(var.value));
-   }
-   
-   var.key = "nestopia_audio_vol_dpcm";
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      sound.SetVolume(Api::Sound::CHANNEL_DPCM, atoi(var.value));
-   }
-   
-   var.key = "nestopia_audio_vol_fds";
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      sound.SetVolume(Api::Sound::CHANNEL_FDS, atoi(var.value));
-   }
-   
-   var.key = "nestopia_audio_vol_mmc5";
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      sound.SetVolume(Api::Sound::CHANNEL_MMC5, atoi(var.value));
-   }
-   
-   var.key = "nestopia_audio_vol_vrc6";
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      sound.SetVolume(Api::Sound::CHANNEL_VRC6, atoi(var.value));
-   }
-   
-   var.key = "nestopia_audio_vol_vrc7";
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      sound.SetVolume(Api::Sound::CHANNEL_VRC7, atoi(var.value));
-   }
-
-   var.key = "nestopia_audio_vol_n163";
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      sound.SetVolume(Api::Sound::CHANNEL_N163, atoi(var.value));
-   }
-   
-   var.key = "nestopia_audio_vol_s5b";
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      sound.SetVolume(Api::Sound::CHANNEL_S5B, atoi(var.value));
-   }
-
-   var.key = "nestopia_audio_type";
+   var.key = "nestopia_nospritelimit";
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
    {
-      if (strcmp(var.value, "mono") == 0)
-      {
-         sound.SetSpeaker(Api::Sound::SPEAKER_MONO);
-      }
-      else
-      {
-         sound.SetSpeaker(Api::Sound::SPEAKER_STEREO);
-      }
+      if (strcmp(var.value, "disabled") == 0)
+         video.EnableUnlimSprites(false);
+      else if (strcmp(var.value, "enabled") == 0)
+         video.EnableUnlimSprites(true);
    }
 
-  /* "Show settings" are not required if categories are supported */
-  option_display.visible = !libretro_supports_option_categories;
-  option_display.key = "nestopia_show_advanced_av_settings";
-  environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+   var.key = "nestopia_overclock";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
+   {
+      if (strcmp(var.value, "1x") == 0)
+         video.EnableOverclocking(false);
+      else if (strcmp(var.value, "2x") == 0)
+         video.EnableOverclocking(true);
+   }
 
-  var.key = "nestopia_show_advanced_av_settings";
-  
-  var.value = NULL;
-  if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-  {
-    bool show_advanced_av_settings_prev = show_advanced_av_settings;
+   var.key = "nestopia_ram_power_state";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
+   {
+      if (strcmp(var.value, "0x00") == 0)
+         machine.SetRamPowerState(0);
+      else if (strcmp(var.value, "0xFF") == 0)
+         machine.SetRamPowerState(1);
+      else if (strcmp(var.value, "random") == 0)
+         machine.SetRamPowerState(2);
+   }
 
-    show_advanced_av_settings = true;
-    if (strcmp(var.value, "disabled") == 0)
-      show_advanced_av_settings = false;
-
-    if (show_advanced_av_settings != show_advanced_av_settings_prev)
-    {
-      size_t i;
-      char av_keys[11][40] = {
-        "nestopia_audio_vol_sq1",
-        "nestopia_audio_vol_sq2",
-        "nestopia_audio_vol_tri",
-        "nestopia_audio_vol_noise",
-        "nestopia_audio_vol_dpcm",
-        "nestopia_audio_vol_fds",
-        "nestopia_audio_vol_mmc5",
-        "nestopia_audio_vol_vrc6",
-        "nestopia_audio_vol_vrc7",
-        "nestopia_audio_vol_n163",
-        "nestopia_audio_vol_s5b"
-      };
-
-      option_display.visible = show_advanced_av_settings
-                               || libretro_supports_option_categories;
-
-      for (i = 0; i < 11; i++)
-      {
-        option_display.key = av_keys[i];
-        environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
-      }
-    }
-  }
-  
 }
 
 void retro_run(void)

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1010,7 +1010,7 @@ static void check_variables(void)
 
    /* System */
 
-   var.key = "nestopia_favored_system";
+   var.key = "nestopia_favored_system"; // System Region
    is_pal = false;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
    {
@@ -1060,11 +1060,11 @@ static void check_variables(void)
    if (audio) delete audio;
    audio = new Api::Sound::Output(audio_buffer, is_pal ? SAMPLERATE / 50 : SAMPLERATE / 60);
 
-   var.key = "nestopia_fds_auto_insert";
+   var.key = "nestopia_fds_auto_insert"; // FDS Auto Insert
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
       fds_auto_insert = (strcmp(var.value, "enabled") == 0);
 
-   var.key = "nestopia_fds_savefile_format";
+   var.key = "nestopia_fds_savefile_format"; // FDS Savefile Format
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
    {
       if (strcmp(var.value, "sav_ups") == 0)
@@ -1086,7 +1086,7 @@ static void check_variables(void)
 
    /* Video */
 
-   var.key = "nestopia_blargg_ntsc_filter";
+   var.key = "nestopia_blargg_ntsc_filter"; // Blargg NTSC Filter
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
    {
       if (strcmp(var.value, "disabled") == 0)
@@ -1103,12 +1103,12 @@ static void check_variables(void)
 
    switch(blargg_ntsc)
    {
-      case 0:
+      case 0: // Disabled
          filter = Api::Video::RenderState::FILTER_NONE;
          video_width = Api::Video::Output::WIDTH;
          video.SetSaturation(Api::Video::DEFAULT_SATURATION);
          break;
-      case 2:
+      case 2: // Composite Video
          filter = Api::Video::RenderState::FILTER_NTSC;
          video.SetSharpness(Api::Video::DEFAULT_SHARPNESS_COMP);
          video.SetColorResolution(Api::Video::DEFAULT_COLOR_RESOLUTION_COMP);
@@ -1118,7 +1118,7 @@ static void check_variables(void)
          video.SetSaturation(Api::Video::DEFAULT_SATURATION_COMP);
          video_width = Api::Video::Output::NTSC_WIDTH;
          break;
-      case 3:
+      case 3: // S-Video
          filter = Api::Video::RenderState::FILTER_NTSC;
          video.SetSharpness(Api::Video::DEFAULT_SHARPNESS_SVIDEO);
          video.SetColorResolution(Api::Video::DEFAULT_COLOR_RESOLUTION_SVIDEO);
@@ -1128,7 +1128,7 @@ static void check_variables(void)
          video.SetSaturation(Api::Video::DEFAULT_SATURATION_SVIDEO);
          video_width = Api::Video::Output::NTSC_WIDTH;
          break;
-      case 4:
+      case 4: // RGB Scart
          filter = Api::Video::RenderState::FILTER_NTSC;
          video.SetSharpness(Api::Video::DEFAULT_SHARPNESS_RGB);
          video.SetColorResolution(Api::Video::DEFAULT_COLOR_RESOLUTION_RGB);
@@ -1138,7 +1138,7 @@ static void check_variables(void)
          video.SetSaturation(Api::Video::DEFAULT_SATURATION_RGB);
          video_width = Api::Video::Output::NTSC_WIDTH;
          break;
-     case 5:
+     case 5: // Monochrome
          filter = Api::Video::RenderState::FILTER_NTSC;
          video.SetSharpness(Api::Video::DEFAULT_SHARPNESS_MONO);
          video.SetColorResolution(Api::Video::DEFAULT_COLOR_RESOLUTION_MONO);
@@ -1150,7 +1150,7 @@ static void check_variables(void)
          break;
    }
 
-   var.key = "nestopia_palette";
+   var.key = "nestopia_palette"; // Palette
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
    {
       if (strcmp(var.value, "consumer") == 0) {
@@ -1233,27 +1233,27 @@ static void check_variables(void)
       }
    }
 
-   var.key = "nestopia_overscan_v_top";
+   var.key = "nestopia_overscan_v_top"; // Mask Overscan (Top Vertical)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var)) {
       overscan_v_top = atoi(var.value);
    }
 
-   var.key = "nestopia_overscan_v_bottom";
+   var.key = "nestopia_overscan_v_bottom"; // Mask Overscan (Bottom Vertical)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var)) {
       overscan_v_bottom = atoi(var.value);
    }
 
-   var.key = "nestopia_overscan_h_left";
+   var.key = "nestopia_overscan_h_left"; // Mask Overscan (Left Horizontal)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var)) {
       overscan_h_left = atoi(var.value);
    }
 
-   var.key = "nestopia_overscan_h_right";
+   var.key = "nestopia_overscan_h_right"; // Mask Overscan (Right Horizontal)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var)) {
       overscan_h_right = atoi(var.value);
    }
 
-   var.key = "nestopia_aspect";
+   var.key = "nestopia_aspect"; // Preferred Aspect Ratio
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (!strcmp(var.value, "ntsc"))
@@ -1270,7 +1270,7 @@ static void check_variables(void)
 
    /* Audio */
 
-   var.key = "nestopia_genie_distortion";
+   var.key = "nestopia_genie_distortion"; // Game Genie Sound Distortion
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
    {
       if (strcmp(var.value, "disabled") == 0)
@@ -1284,7 +1284,7 @@ static void check_variables(void)
    option_display.key = "nestopia_show_advanced_av_settings";
    environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
 
-   var.key = "nestopia_show_advanced_av_settings";
+   var.key = "nestopia_show_advanced_av_settings"; // Show Advanced Audio Settings (Reopen Menu)
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
@@ -1322,51 +1322,51 @@ static void check_variables(void)
       }
    }
 
-   var.key = "nestopia_audio_vol_sq1";
+   var.key = "nestopia_audio_vol_sq1"; // Square 1 Channel Volume %
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
       sound.SetVolume(Api::Sound::CHANNEL_SQUARE1, atoi(var.value));
 
-   var.key = "nestopia_audio_vol_sq2";
+   var.key = "nestopia_audio_vol_sq2"; // Square 2 Channel Volume %
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
       sound.SetVolume(Api::Sound::CHANNEL_SQUARE2, atoi(var.value));
 
-   var.key = "nestopia_audio_vol_tri";
+   var.key = "nestopia_audio_vol_tri"; // Triangle Channel Volume %
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
       sound.SetVolume(Api::Sound::CHANNEL_TRIANGLE, atoi(var.value));
 
-   var.key = "nestopia_audio_vol_noise";
+   var.key = "nestopia_audio_vol_noise"; // Noise Channel Volume %
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
       sound.SetVolume(Api::Sound::CHANNEL_NOISE, atoi(var.value));
 
-   var.key = "nestopia_audio_vol_dpcm";
+   var.key = "nestopia_audio_vol_dpcm"; // DPCM Channel Volume %
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
       sound.SetVolume(Api::Sound::CHANNEL_DPCM, atoi(var.value));
 
-   var.key = "nestopia_audio_vol_fds";
+   var.key = "nestopia_audio_vol_fds"; // FDS Channel Volume %
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
       sound.SetVolume(Api::Sound::CHANNEL_FDS, atoi(var.value));
 
-   var.key = "nestopia_audio_vol_mmc5";
+   var.key = "nestopia_audio_vol_mmc5"; // MMC5 Channel Volume %
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
       sound.SetVolume(Api::Sound::CHANNEL_MMC5, atoi(var.value));
 
-   var.key = "nestopia_audio_vol_vrc6";
+   var.key = "nestopia_audio_vol_vrc6"; // VRC6 Channel Volume %
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
       sound.SetVolume(Api::Sound::CHANNEL_VRC6, atoi(var.value));
 
-   var.key = "nestopia_audio_vol_vrc7";
+   var.key = "nestopia_audio_vol_vrc7"; // VRC7 Channel Volume %
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
       sound.SetVolume(Api::Sound::CHANNEL_VRC7, atoi(var.value));
 
-   var.key = "nestopia_audio_vol_n163";
+   var.key = "nestopia_audio_vol_n163"; // N163 Channel Volume %
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
       sound.SetVolume(Api::Sound::CHANNEL_N163, atoi(var.value));
 
-   var.key = "nestopia_audio_vol_s5b";
+   var.key = "nestopia_audio_vol_s5b"; // S5B Channel Volume %
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
       sound.SetVolume(Api::Sound::CHANNEL_S5B, atoi(var.value));
 
-   var.key = "nestopia_audio_type";
+   var.key = "nestopia_audio_type"; // Audio output
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
    {
       if (strcmp(var.value, "mono") == 0)
@@ -1377,7 +1377,7 @@ static void check_variables(void)
 
    /* Input */
 
-   var.key = "nestopia_select_adapter";
+   var.key = "nestopia_select_adapter"; // 4 Player Adapter
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
        if (!strcmp(var.value, "auto")) {
@@ -1391,7 +1391,7 @@ static void check_variables(void)
         }
    }
 
-   var.key = "nestopia_button_shift";
+   var.key = "nestopia_button_shift"; // Shift Buttons Clockwise
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
    {
       if (strcmp(var.value, "disabled") == 0)
@@ -1400,7 +1400,7 @@ static void check_variables(void)
          bindmap = bindmap_shifted;
    }
 
-   var.key = "nestopia_arkanoid_device";
+   var.key = "nestopia_arkanoid_device"; // Arkanoid Device
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
    {
       if (strcmp(var.value, "mouse") == 0)
@@ -1412,7 +1412,7 @@ static void check_variables(void)
    // https://www.nesdev.org/wiki/Arkanoid_controller
    // There are two different Arkanoid (or Vaus) controllers.
    // And each controller has a slightly different range of values.
-   var.key = "nestopia_arkanoid_paddle_range";
+   var.key = "nestopia_arkanoid_paddle_range"; // Arkanoid Paddle Range
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
    {
       // Default full range that will work for both arkanoidI and arkanoidII
@@ -1430,7 +1430,7 @@ static void check_variables(void)
       }
    }
 
-   var.key = "nestopia_zapper_device";
+   var.key = "nestopia_zapper_device"; // Zapper Device
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
    {
       if (strcmp(var.value, "lightgun") == 0)
@@ -1441,7 +1441,7 @@ static void check_variables(void)
          zapper_device = ZAPPER_DEVICE_POINTER;
    }
 
-   var.key = "nestopia_show_crosshair";
+   var.key = "nestopia_show_crosshair"; // Show Crosshair
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
    {
       if (strcmp(var.value, "disabled") == 0)
@@ -1450,7 +1450,7 @@ static void check_variables(void)
          show_crosshair = SHOW_CROSSHAIR_OFF;
    }
 
-   var.key = "nestopia_turbo_pulse";
+   var.key = "nestopia_turbo_pulse"; // Turbo Pulse Speed
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
       tpulse = atoi(var.value);
 
@@ -1471,7 +1471,7 @@ static void check_variables(void)
 
    /* Emulation Hacks */
 
-   var.key = "nestopia_nospritelimit";
+   var.key = "nestopia_nospritelimit"; // Remove Sprite Limit
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
    {
       if (strcmp(var.value, "disabled") == 0)
@@ -1480,7 +1480,7 @@ static void check_variables(void)
          video.EnableUnlimSprites(true);
    }
 
-   var.key = "nestopia_overclock";
+   var.key = "nestopia_overclock"; // CPU Speed (Overclock)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
    {
       if (strcmp(var.value, "1x") == 0)
@@ -1489,7 +1489,7 @@ static void check_variables(void)
          video.EnableOverclocking(true);
    }
 
-   var.key = "nestopia_ram_power_state";
+   var.key = "nestopia_ram_power_state"; // RAM Power-on State
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
    {
       if (strcmp(var.value, "0x00") == 0)

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1234,24 +1234,20 @@ static void check_variables(void)
    }
 
    var.key = "nestopia_overscan_v_top"; // Mask Overscan (Top Vertical)
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var)) {
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
       overscan_v_top = atoi(var.value);
-   }
 
    var.key = "nestopia_overscan_v_bottom"; // Mask Overscan (Bottom Vertical)
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var)) {
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
       overscan_v_bottom = atoi(var.value);
-   }
 
    var.key = "nestopia_overscan_h_left"; // Mask Overscan (Left Horizontal)
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var)) {
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
       overscan_h_left = atoi(var.value);
-   }
 
    var.key = "nestopia_overscan_h_right"; // Mask Overscan (Right Horizontal)
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var)) {
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
       overscan_h_right = atoi(var.value);
-   }
 
    var.key = "nestopia_aspect"; // Preferred Aspect Ratio
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)


### PR DESCRIPTION
In the current Nestopia libretro core, the core option order as shown in the `check_variables()` function in `libretro.cpp` appears to be quite messy. It does not reflect the categories and individual order defined by the `libretro_core_options.h` file and visualized on-screen.

This PR aims to rectify this, by introducing the following changes:

- All core options listed in the `check_variables()` function were reordered and divided by category (ie "System", "Video", etc.) to closely match what already exists in the `libretro_core_options.h` file.
- Comments were added next to each variable definition in `check_variables()`, with the respective on-screen name that was given to each option. This is a change made for the sake of convenience, because some of the variable names differ quite a bit from the on-screen name seen when running the core. This should make the options more easily identifiable and the code itself a bit easier to decipher.
- Some minor style adjustments were made to improve consistency across the options.

All the changes are libretro-specific and contained in `libretro.cpp`, with no alteration to functionality.
Tested on Windows 11 x64



